### PR TITLE
chore: remove HoundCI config

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,4 +1,0 @@
-eslint:
-  enabled: true
-  config_file: .eslintrc.json
-  version: 7.7.0


### PR DESCRIPTION
Removes `.hound.yml`. Hound CI is no longer in active use for this repository; linting is handled by the project's own ESLint setup.

Note: this file is also already removed on the `v2` branch (PR #16) as part of the legacy tooling cleanup, but landing it independently here keeps `main` clean regardless of when v2 merges.