### PR TITLE
docs: add AGENTS.md and github-pr opencode skill

### DIFF
--- a/.opencode/skills/github-pr/SKILL.md
+++ b/.opencode/skills/github-pr/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: github-pr
+description: Use when creating a GitHub pull request in this repo. Ensures the PR is assigned to the repo owner and linked to the originating issue and milestone.
+---
+
+# GitHub PR
+
+Whenever you create a pull request in this repository (via `gh pr create`
+or any other mechanism), you **must** ensure all three of:
+
+1. **Assignee:** `ramongr` is set as the assignee.
+2. **Issue link:** the PR body contains `Closes #<issue>` so GitHub
+   auto-closes the issue on merge.
+3. **Milestone:** the PR is attached to the same milestone as the
+   originating issue (e.g. `v2.1`, `v2.2`, `v2.3`). PRs without an
+   originating issue are attached to the milestone they target.
+
+## How
+
+```sh
+# Look up the issue's milestone first
+MILESTONE=$(gh issue view <issue> --json milestone --jq '.milestone.title')
+
+gh pr create \
+  --title "<conventional-commit subject>" \
+  --base main \
+  --assignee ramongr \
+  --milestone "$MILESTONE" \
+  --body "$(cat <<'EOF'
+## Summary
+...
+
+## Changes
+- ...
+
+Closes #<issue>
+EOF
+)"
+```
+
+## If you forgot
+
+Fix any opened PR immediately:
+
+```sh
+gh pr edit <pr-number> --add-assignee ramongr
+gh pr edit <pr-number> --milestone "<milestone-title>"
+# To add the issue link, edit the body to include "Closes #<issue>".
+```
+
+## Why
+
+- **Assignee** surfaces the PR in the owner's dashboard for review.
+- **`Closes #<issue>`** lets GitHub auto-close the issue and keeps the
+  release notes traceable.
+- **Milestone** keeps the v2.x roadmap accurate; release notes are
+  generated from the milestone view.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,13 @@ Run these before pushing. CI runs the same matrix on Node 20 and 22.
   `CHANGELOG.md` entry.
 - Don't merge your own PRs, don't force-push to `main`, don't `--amend`
   pushed commits.
+- **Always assign the repo owner, link the issue, and set the milestone.**
+  See the `github-pr` skill in `.opencode/skills/github-pr/SKILL.md`
+  for the exact `gh pr create` invocation. Every PR in this repo must:
+  - have `ramongr` as the assignee,
+  - include `Closes #<issue>` in the body,
+  - be attached to the same milestone as the originating issue
+    (e.g. `v2.1`).
 
 ## Tooling
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,157 @@
+# AGENTS.md
+
+Conventions for any human or agent contributing to **op-array**. Read this
+before opening a PR. Everything below is enforced by review or by
+`npm run lint && npm run typecheck && npm test && npm run build`.
+
+## Project layout
+
+```
+src/
+  <category>/
+    <functionName>.ts      # one function per file
+    index.ts               # re-exports every function in the category
+  shared/                  # internal helpers (not part of the public API)
+  index.ts                 # re-exports every category
+tests/
+  <category>/
+    <category>.test.ts     # one file per category, one describe per function
+  shared/
+    <helper>.test.ts       # one file per shared helper
+docs/
+  <category>.md            # public docs per category
+```
+
+Categories: `collections`, `logical`, `numerical`, `positional`,
+`transformations`. Each category is also published as a subpath
+(`op-array/collections`, etc.); keep the category boundary intentional.
+
+## Code style
+
+- **Named `export function`** declarations only. No default exports, no
+  `export const fn = () => …`.
+- **Explicit return types** are required (eslint enforces).
+- Inputs are **`readonly T[]`** unless mutation is unavoidable.
+- Relative imports use the **`.js` suffix** (NodeNext/ESM resolution).
+- Use **`import type`** for type-only imports (eslint enforces
+  `consistent-type-imports`).
+- Avoid `any`. `unknown` is fine when truly unknown.
+- JSDoc on every exported function: one-line summary, then `@example`
+  when the call shape isn't obvious from the signature, then `@throws`
+  when applicable.
+- No `console.*` in `src/`.
+
+### Empty-input policy
+
+Match the v2.0 precedent. New functions must pick the option that fits
+their category and document it.
+
+| Operation kind        | Empty input           | Examples            |
+|-----------------------|-----------------------|---------------------|
+| Additive aggregate    | identity (`0`)        | `sum`               |
+| Multiplicative / fold | `TypeError`           | `product`, `subtract`, `median` |
+| Statistical mean      | `NaN`                 | `average`           |
+| Set / list result     | `[]`                  | `mode`, `unique`, `intersection`, `pluck` |
+| Boolean predicate     | `false` (document)    | `exists`, `existsAll`, `existsAny` |
+| Map / index result    | `{}`                  | `keyBy`, `groupBy`, `countBy` |
+| Pair-of-lists result  | both empty            | `partition` -> `{ pass: [], fail: [] }` |
+
+Throw `RangeError` for invalid numeric arguments (e.g. group size ≤ 0)
+and `TypeError` for empty arrays where the result is mathematically
+undefined.
+
+### Dot-path key access
+
+Any function that takes a `key: string` argument resolves it as a
+dot-delimited path through `src/shared/pathResolver.ts` (which delegates
+to `nestedObjectValue`). This is the single, consistent way to address
+nested fields across the API. Never accept a callback as an alternative
+overload.
+
+```ts
+import { pathResolver } from '../shared/pathResolver.js';
+
+const at = pathResolver(key);
+collection.map(at);
+```
+
+## Test style
+
+- Vitest. One `tests/<category>/<category>.test.ts` per category, with
+  a top-level `describe(<functionName>)` per function.
+- Each function must cover at minimum:
+  1. happy path
+  2. empty-input behaviour (per the table above)
+  3. any documented edge case (no-mutation, ordering, throws, missing
+     path resolves to `undefined`, duplicate keys, etc.)
+- Imports go through the category index:
+  `import { pluck } from '../../src/collections/index.js';`
+- Use `.toEqual` for structural equality, `.toBe` for primitives, and
+  `.toThrow(TypeError)` / `.toThrow(RangeError)` for error contracts.
+
+## Documentation
+
+Every PR that adds, renames, or changes the contract of a public
+function must update **all three** of:
+
+1. `docs/<category>.md` — section per function with at least one
+   runnable example. Keep the same heading shape as siblings:
+   `## ` + `` `name(arg, arg)` ``.
+2. `README.md` — the **API overview** table.
+3. `CHANGELOG.md` — an entry under `## [2.1.0]` (Keep a Changelog
+   format). Group entries under `### Added`, `### Changed`,
+   `### Fixed`, `### Tooling`.
+
+Internal-only changes (under `src/shared/`) only need the `CHANGELOG`
+entry under `### Tooling` or no entry at all.
+
+## Quality gate
+
+Every commit pushed to a PR must pass, locally and in CI:
+
+```sh
+npm run lint
+npm run typecheck
+npm test
+npm run build
+```
+
+Run these before pushing. CI runs the same matrix on Node 20 and 22.
+
+## Git & PR workflow
+
+- **Base branch:** `main`. No long-lived integration branch.
+- **One issue → one branch → one PR.**
+- **Branch names:** `feat/<issue>-<slug>`, `fix/<issue>-<slug>`,
+  `chore/<issue>-<slug>`, `docs/<slug>`.
+  Examples: `feat/19-pluck`, `chore/24-dot-path-audit`.
+- **Conventional Commits** for the PR's main commit:
+  `feat(<category>): add <name> (#<issue>)`,
+  `fix(<category>): …`, `chore: …`, `docs: …`.
+- **PR title** mirrors the commit subject.
+- **PR body** uses this template:
+
+  ```md
+  ## Summary
+  One- or two-sentence description of intent.
+
+  ## Changes
+  - bullet per noteworthy change
+  - tests / docs / changelog updated
+
+  Closes #<issue>
+  ```
+
+- A PR adding a public function is **self-contained**: implementation,
+  tests, `docs/<category>.md` entry, README table update, and
+  `CHANGELOG.md` entry.
+- Don't merge your own PRs, don't force-push to `main`, don't `--amend`
+  pushed commits.
+
+## Tooling
+
+- Node ≥ 20 (managed via [mise](https://mise.jdx.dev), see `mise.toml`).
+- Package manager: `npm`.
+- Build: `tsup` (dual ESM + CJS, types per entry).
+- Tests: `vitest` with v8 coverage.
+- Lint: `eslint` v9 flat config + `typescript-eslint`.


### PR DESCRIPTION
## Summary
Encode the project's conventions in a single root-level `AGENTS.md` and ship the `github-pr` opencode skill that enforces the PR workflow (assignee, issue link, milestone) for every contributor — human or agent — before opening v2.1 PRs.

## Changes
- New `AGENTS.md` covering layout, code style, empty-input policy, dot-path key access, test/docs/changelog policy, quality gate, and git/PR workflow. Cross-references the new skill.
- New `.opencode/skills/github-pr/SKILL.md` requiring every PR in this repo to: be assigned to `ramongr`, include `Closes #<issue>`, and be attached to the originating issue's milestone (e.g. `v2.1`).
- No source / test / build changes.