### PR TITLE
feat(shared): add internal pathResolver helper (#18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0]
+
+### Tooling
+
+- Added internal `pathResolver(path)` helper in `src/shared/` to centralise
+  dot-path access for upcoming `*By` helpers.
+
 ## [2.0.0] - 2026-05-04
 
 ### Breaking changes

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,2 +1,3 @@
 export * from './arithmetic.js';
 export * from './nestedObject.js';
+export * from './pathResolver.js';

--- a/src/shared/pathResolver.ts
+++ b/src/shared/pathResolver.ts
@@ -1,0 +1,18 @@
+import { nestedObjectValue } from './nestedObject.js';
+
+/**
+ * Builds an accessor that returns the value at a dot-delimited `path`
+ * for any item, delegating to {@link nestedObjectValue}.
+ *
+ * Centralises dot-path access so every key-taking function in the
+ * library resolves keys identically. Internal helper — not part of the
+ * public API.
+ *
+ * @example
+ * const at = pathResolver('user.name');
+ * at({ user: { name: 'Ana' } }); // 'Ana'
+ * at({ user: {} });              // undefined
+ */
+export function pathResolver(path: string): (item: unknown) => unknown {
+  return (item) => nestedObjectValue(item, path);
+}

--- a/tests/shared/pathResolver.test.ts
+++ b/tests/shared/pathResolver.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'vitest';
+import { pathResolver } from '../../src/shared/pathResolver.js';
+
+describe('pathResolver', () => {
+  test('resolves a top-level key', () => {
+    const at = pathResolver('id');
+    expect(at({ id: 1 })).toBe(1);
+  });
+
+  test('resolves a nested dot-delimited path', () => {
+    const at = pathResolver('user.profile.name');
+    expect(at({ user: { profile: { name: 'Ana' } } })).toBe('Ana');
+  });
+
+  test('returns undefined when a segment is missing', () => {
+    const at = pathResolver('user.profile.name');
+    expect(at({ user: {} })).toBeUndefined();
+  });
+
+  test('returns undefined when walking into a primitive', () => {
+    const at = pathResolver('foo.bar');
+    expect(at(42)).toBeUndefined();
+    expect(at(null)).toBeUndefined();
+    expect(at(undefined)).toBeUndefined();
+  });
+
+  test('returns the same accessor for repeated calls (no memoisation, no closure leak)', () => {
+    const at = pathResolver('a');
+    expect(at({ a: 1 })).toBe(1);
+    expect(at({ a: 2 })).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
Add an internal `pathResolver(path)` helper that returns an accessor delegating to `nestedObjectValue`. Centralises dot-path access so the upcoming `*By` family (`pluck`, `keyBy`, `groupBy`, `countBy`, `uniqueBy`) all resolve keys identically to `findBy` / `where`.

## Changes
- `src/shared/pathResolver.ts` with full JSDoc
- Re-exported from `src/shared/index.ts`
- `tests/shared/pathResolver.test.ts` covering nested paths, missing segments, primitive walk-through, and accessor reuse
- `CHANGELOG.md` entry under `## [2.1.0]` -> `### Tooling`

Internal helper, not exported from the public `src/index.ts`.

Closes #18