### PR TITLE
feat(collections): add partition (#23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0]
+
+### Added
+
+- `partition(collection, predicate)`: single-pass split into
+  `{ pass, fail }` buckets.
+
 ## [2.0.0] - 2026-05-04
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Subpaths available: `op-array/collections`, `op-array/logical`,
 
 | Category | Functions |
 |---|---|
-| **Collections** | `findBy`, `findById`, `where`, `extract` |
+| **Collections** | `findBy`, `findById`, `where`, `extract`, `partition` |
 | **Logical** | `intersection`, `except`, `union`, `exists`, `existsAll` |
 | **Numerical** | `min`, `max`, `sum`, `subtract`, `product`, `average`, `hasEvenLength`, `median`, `mode` |
 | **Positional** | `first`, `second`, `third`, `last` |

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -6,6 +6,7 @@ import {
   findById,
   where,
   extract,
+  partition,
 } from 'op-array/collections';
 ```
 
@@ -57,4 +58,21 @@ extract(
   ['id', 'name'],
 );
 // [{ id: 1, name: 'Ana' }]
+```
+
+## `partition(collection, predicate)`
+
+Splits the collection into two arrays in a single pass. Items for which
+`predicate` returns `true` go into `pass`, the rest into `fail`. The
+predicate must return a boolean — truthy/falsy values are not coerced.
+Empty input returns `{ pass: [], fail: [] }`.
+
+```ts
+partition([1, 2, 3, 4], (n) => n % 2 === 0);
+// { pass: [2, 4], fail: [1, 3] }
+
+const { pass: adults, fail: minors } = partition(
+  users,
+  (u) => u.age >= 18,
+);
 ```

--- a/src/collections/index.ts
+++ b/src/collections/index.ts
@@ -2,3 +2,4 @@ export { findBy } from './findBy.js';
 export { findById } from './findById.js';
 export { where } from './where.js';
 export { extract } from './extract.js';
+export { partition } from './partition.js';

--- a/src/collections/partition.ts
+++ b/src/collections/partition.ts
@@ -1,0 +1,31 @@
+/**
+ * Splits a collection into two arrays in a single pass: items where
+ * `predicate` returns `true` go into `pass`, the rest into `fail`.
+ *
+ * The predicate result is required to be a boolean — truthy/falsy
+ * values are not coerced.
+ *
+ * @example
+ * partition([1, 2, 3, 4], (n) => n % 2 === 0);
+ * // { pass: [2, 4], fail: [1, 3] }
+ *
+ * partition<number>([], (n) => n > 0);
+ * // { pass: [], fail: [] }
+ */
+export function partition<T>(
+  collection: readonly T[],
+  predicate: (item: T, index: number) => boolean,
+): { pass: T[]; fail: T[] } {
+  const pass: T[] = [];
+  const fail: T[] = [];
+
+  collection.forEach((item, index) => {
+    if (predicate(item, index)) {
+      pass.push(item);
+    } else {
+      fail.push(item);
+    }
+  });
+
+  return { pass, fail };
+}

--- a/tests/collections/collections.test.ts
+++ b/tests/collections/collections.test.ts
@@ -3,6 +3,7 @@ import {
   extract,
   findBy,
   findById,
+  partition,
   where,
 } from '../../src/collections/index.js';
 
@@ -67,5 +68,40 @@ describe('extract', () => {
       { id: 1, name: 'Ana' },
       { id: 2, name: 'Bo' },
     ]);
+  });
+});
+
+describe('partition', () => {
+  test('splits items by predicate into pass / fail buckets', () => {
+    expect(partition([1, 2, 3, 4], (n) => n % 2 === 0)).toEqual({
+      pass: [2, 4],
+      fail: [1, 3],
+    });
+  });
+
+  test('passes the index to the predicate', () => {
+    expect(
+      partition(['a', 'b', 'c', 'd'], (_item, index) => index < 2),
+    ).toEqual({ pass: ['a', 'b'], fail: ['c', 'd'] });
+  });
+
+  test('returns both buckets empty for empty input', () => {
+    expect(partition<number>([], (n) => n > 0)).toEqual({
+      pass: [],
+      fail: [],
+    });
+  });
+
+  test('preserves source order within each bucket', () => {
+    const items = [3, 1, 4, 1, 5, 9, 2, 6];
+    const { pass, fail } = partition(items, (n) => n > 2);
+    expect(pass).toEqual([3, 4, 5, 9, 6]);
+    expect(fail).toEqual([1, 1, 2]);
+  });
+
+  test('does not mutate the input', () => {
+    const input = [1, 2, 3];
+    partition(input, (n) => n > 1);
+    expect(input).toEqual([1, 2, 3]);
   });
 });


### PR DESCRIPTION
## Summary
Add `partition(collection, predicate)`: a single-pass split into `{ pass, fail }` buckets. Avoids the two-`filter` pattern and uses an object return shape (instead of a tuple) so destructured names self-document at the call site.

## Changes
- `src/collections/partition.ts`
- Re-exported from `src/collections/index.ts`
- Tests in `tests/collections/collections.test.ts` (predicate, index argument, empty input, order preservation, no mutation)
- Doc section in `docs/collections.md`
- README API table updated
- `CHANGELOG.md` entry under `## [2.1.0]` -> `### Added`

Closes #23