### PR TITLE
feat(logical): add existsAny (#25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0]
+
+### Added
+
+- `existsAny(source, items)`: disjunctive sibling of `existsAll`.
+
 ## [2.0.0] - 2026-05-04
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Subpaths available: `op-array/collections`, `op-array/logical`,
 | Category | Functions |
 |---|---|
 | **Collections** | `findBy`, `findById`, `where`, `extract` |
-| **Logical** | `intersection`, `except`, `union`, `exists`, `existsAll` |
+| **Logical** | `intersection`, `except`, `union`, `exists`, `existsAll`, `existsAny` |
 | **Numerical** | `min`, `max`, `sum`, `subtract`, `product`, `average`, `hasEvenLength`, `median`, `mode` |
 | **Positional** | `first`, `second`, `third`, `last` |
 | **Transformations** | `unique`, `flat`, `inGroups`, `inGroupsOf`, `occurrences`, `compact`, `compactNullish` |

--- a/docs/logical.md
+++ b/docs/logical.md
@@ -7,6 +7,7 @@ import {
   union,
   exists,
   existsAll,
+  existsAny,
 } from 'op-array/logical';
 ```
 
@@ -50,4 +51,16 @@ empty.
 existsAll([1, 2, 3], [1, 3]); // true
 existsAll([1, 2, 3], [1, 9]); // false
 existsAll([], [1]);           // false
+```
+
+## `existsAny(source, items)`
+
+True when **any** element of `items` is in `source`. False if either
+side is empty.
+
+```ts
+existsAny([1, 2, 3], [4, 2]); // true
+existsAny([1, 2, 3], [4, 5]); // false
+existsAny([], [1]);           // false
+existsAny([1], []);           // false
 ```

--- a/src/logical/existsAny.ts
+++ b/src/logical/existsAny.ts
@@ -1,0 +1,23 @@
+/**
+ * Reports whether **any** item in `items` exists in `source`. The
+ * disjunctive sibling of {@link existsAll}.
+ *
+ * Returns `false` for an empty `items` list (nothing to find) and
+ * `false` for an empty `source` regardless of `items`.
+ *
+ * @example
+ * existsAny([1, 2, 3], [4, 2]); // true
+ * existsAny([1, 2, 3], [4, 5]); // false
+ * existsAny([], [1]);           // false
+ * existsAny([1], []);           // false
+ */
+export function existsAny<T>(
+  source: readonly T[],
+  items: readonly T[],
+): boolean {
+  if (source.length === 0 || items.length === 0) {
+    return false;
+  }
+  const sourceSet = new Set(source);
+  return items.some((item) => sourceSet.has(item));
+}

--- a/src/logical/index.ts
+++ b/src/logical/index.ts
@@ -2,3 +2,4 @@ export { intersection } from './intersection.js';
 export { except } from './except.js';
 export { union } from './union.js';
 export { exists, existsAll } from './exists.js';
+export { existsAny } from './existsAny.js';

--- a/tests/logical/logical.test.ts
+++ b/tests/logical/logical.test.ts
@@ -3,6 +3,7 @@ import {
   except,
   exists,
   existsAll,
+  existsAny,
   intersection,
   union,
 } from '../../src/logical/index.js';
@@ -75,5 +76,23 @@ describe('existsAll', () => {
 
   test('returns true vacuously for empty items on non-empty source', () => {
     expect(existsAll([1], [])).toBe(true);
+  });
+});
+
+describe('existsAny', () => {
+  test('returns true when at least one item is present', () => {
+    expect(existsAny([1, 2, 3], [4, 2])).toBe(true);
+  });
+
+  test('returns false when no item is present', () => {
+    expect(existsAny([1, 2, 3], [4, 5])).toBe(false);
+  });
+
+  test('returns false on empty source', () => {
+    expect(existsAny<number>([], [1])).toBe(false);
+  });
+
+  test('returns false on empty items', () => {
+    expect(existsAny([1], [])).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
Add `existsAny(source, items)` — the disjunctive sibling of `existsAll`. Returns `true` when at least one element of `items` is in `source`. Uses a `Set` for O(n + m) lookup.

## Changes
- `src/logical/existsAny.ts`
- Re-exported from `src/logical/index.ts`
- Tests in `tests/logical/logical.test.ts` (happy / no overlap / empty source / empty items)
- Doc section in `docs/logical.md`
- README API table updated
- `CHANGELOG.md` entry under `## [2.1.0]` -> `### Added`

Closes #25