### PR TITLE
feat(logical): add equals (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0]
+
+### Added
+
+- `equals(left, right)`: order- and duplicate-insensitive set-equality
+  for arrays.
+
 ## [2.0.0] - 2026-05-04
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Subpaths available: `op-array/collections`, `op-array/logical`,
 | Category | Functions |
 |---|---|
 | **Collections** | `findBy`, `findById`, `where`, `extract` |
-| **Logical** | `intersection`, `except`, `union`, `exists`, `existsAll` |
+| **Logical** | `intersection`, `except`, `union`, `exists`, `existsAll`, `equals` |
 | **Numerical** | `min`, `max`, `sum`, `subtract`, `product`, `average`, `hasEvenLength`, `median`, `mode` |
 | **Positional** | `first`, `second`, `third`, `last` |
 | **Transformations** | `unique`, `flat`, `inGroups`, `inGroupsOf`, `occurrences`, `compact`, `compactNullish` |

--- a/docs/logical.md
+++ b/docs/logical.md
@@ -7,6 +7,7 @@ import {
   union,
   exists,
   existsAll,
+  equals,
 } from 'op-array/logical';
 ```
 
@@ -50,4 +51,17 @@ empty.
 existsAll([1, 2, 3], [1, 3]); // true
 existsAll([1, 2, 3], [1, 9]); // false
 existsAll([], [1]);           // false
+```
+
+## `equals(left, right)`
+
+Set-equality. `true` when both arrays contain exactly the same distinct
+elements regardless of order or duplicates. **Not** a deep equality
+check. Element comparison uses `Set` (SameValueZero) semantics.
+
+```ts
+equals([1, 2, 3], [3, 2, 1]); // true
+equals([1, 2], [1, 2, 2]);    // true  (set semantics)
+equals([1, 2], [1, 3]);       // false
+equals([], []);               // true
 ```

--- a/src/logical/equals.ts
+++ b/src/logical/equals.ts
@@ -1,0 +1,27 @@
+/**
+ * Set-equality check: returns `true` when both arrays contain exactly
+ * the same distinct elements, regardless of order or duplicates.
+ *
+ * This is **not** a deep equality check. Element comparison uses the
+ * same identity semantics as `Set` (SameValueZero).
+ *
+ * @example
+ * equals([1, 2, 3], [3, 2, 1]); // true
+ * equals([1, 2], [1, 2, 2]);    // true  (set semantics)
+ * equals([1, 2], [1, 3]);       // false
+ * equals([], []);               // true
+ */
+export function equals<T>(left: readonly T[], right: readonly T[]): boolean {
+  const leftSet = new Set(left);
+  const rightSet = new Set(right);
+
+  if (leftSet.size !== rightSet.size) {
+    return false;
+  }
+  for (const item of leftSet) {
+    if (!rightSet.has(item)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/logical/index.ts
+++ b/src/logical/index.ts
@@ -2,3 +2,4 @@ export { intersection } from './intersection.js';
 export { except } from './except.js';
 export { union } from './union.js';
 export { exists, existsAll } from './exists.js';
+export { equals } from './equals.js';

--- a/tests/logical/logical.test.ts
+++ b/tests/logical/logical.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import {
+  equals,
   except,
   exists,
   existsAll,
@@ -75,5 +76,28 @@ describe('existsAll', () => {
 
   test('returns true vacuously for empty items on non-empty source', () => {
     expect(existsAll([1], [])).toBe(true);
+  });
+});
+
+describe('equals', () => {
+  test('returns true for arrays with the same elements in any order', () => {
+    expect(equals([1, 2, 3], [3, 2, 1])).toBe(true);
+  });
+
+  test('returns true ignoring duplicates (set semantics)', () => {
+    expect(equals([1, 2], [1, 2, 2])).toBe(true);
+  });
+
+  test('returns false when distinct elements differ', () => {
+    expect(equals([1, 2], [1, 3])).toBe(false);
+  });
+
+  test('returns true for two empty arrays', () => {
+    expect(equals<number>([], [])).toBe(true);
+  });
+
+  test('returns false when only one side is empty', () => {
+    expect(equals<number>([], [1])).toBe(false);
+    expect(equals<number>([1], [])).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
Add `equals(left, right)` — order- and duplicate-insensitive set-equality for arrays. Documented as **not** a deep equality check, to leave room for a future `deepEquals` if needed.

## Changes
- `src/logical/equals.ts`
- Re-exported from `src/logical/index.ts`
- Tests in `tests/logical/logical.test.ts` (same elements / set semantics / mismatch / both empty / one empty)
- Doc section in `docs/logical.md`
- README API table updated
- `CHANGELOG.md` entry under `## [2.1.0]` -> `### Added`

Closes #30