### PR TITLE
chore: audit key-taking functions for dot-path support (#24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0]
+
+### Documentation
+
+- Documented the dot-path convention for every key-taking function in a
+  new "Conventions" section of the README, with an explicit note that
+  `extract` remains top-level-only (deferred to v3 to avoid a v2
+  breaking change).
+
+### Tests
+
+- Added nested-path coverage for `where` to lock in the convention.
+
 ## [2.0.0] - 2026-05-04
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ import { min, max, average, median } from 'op-array/numerical';
 Subpaths available: `op-array/collections`, `op-array/logical`,
 `op-array/numerical`, `op-array/positional`, `op-array/transformations`.
 
+## Conventions
+
+Any function that takes a `key: string` argument (`findBy`, `where`,
+`pluck`, `keyBy`, `groupBy`, `countBy`, `uniqueBy`, …) resolves it as a
+**dot-delimited path** through the nested object — the same semantics
+as `findBy(arr, 'profile.email', 'a@x')`. Missing segments resolve to
+`undefined`. There is no callback overload; this single, consistent way
+to address fields is intentional.
+
+> **Limitation:** `extract` currently accepts only top-level keys
+> (`keyof T`) for type-safety reasons. Adding dot-path support would
+> change its return type and is therefore deferred to v3. Use `pluck`
+> for single-field projection if you need nested access today.
+
 ## API overview
 
 | Category | Functions |

--- a/tests/collections/collections.test.ts
+++ b/tests/collections/collections.test.ts
@@ -54,6 +54,22 @@ describe('where', () => {
   test('returns an empty array when nothing matches', () => {
     expect(where(users, 'role', 'guest')).toEqual([]);
   });
+
+  test('matches by a nested dot-delimited key', () => {
+    const records = [
+      { profile: { country: 'PT' } },
+      { profile: { country: 'US' } },
+      { profile: { country: 'PT' } },
+    ];
+    expect(where(records, 'profile.country', 'PT')).toEqual([
+      records[0],
+      records[2],
+    ]);
+  });
+
+  test('returns [] when the path is missing on every item', () => {
+    expect(where([{ a: 1 }, { a: 2 }], 'b.c', 1)).toEqual([]);
+  });
 });
 
 describe('extract', () => {


### PR DESCRIPTION
## Summary
Audit the existing v2.0 surface against the dot-path convention and document it. Confirmed compliant: `findBy`, `where`, `findById`. Non-compliant: `extract` (typed `keyof T`, top-level only).

Per the v2.1 scope decision, `extract` is **not** changed — making it accept dot-paths would alter its return type and break v2 consumers. Documented as a known limitation and deferred to v3.

## Changes
- README: new **Conventions** section explicitly defining the dot-path rule and the `extract` exception.
- Tests: added nested-path coverage for `where` (already existed for `findBy`) to lock in the convention.
- `CHANGELOG.md` entries under `## [2.1.0]` (`### Documentation`, `### Tests`).

## Out of scope
- `extract` dot-path support — tracked for v3.
- The new `*By` family lands via #18-#22, #42 with dot-path support from day 1.

Closes #24