### PR TITLE
feat(ci): publish on milestone close

### DIFF
--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -18,6 +18,7 @@ jobs:
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
+    environment: npm-publish
 
     steps:
       - name: Resolve tag
@@ -46,11 +47,8 @@ jobs:
           tool_versions: |
             node 22
 
-      - name: Setup npm registry auth
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Use latest npm (Trusted Publishing requires npm >= 11.5.1)
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci
@@ -72,10 +70,8 @@ jobs:
             exit 1
           fi
 
-      - name: Publish to npm
+      - name: Publish to npm (Trusted Publishing via OIDC)
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         env:

--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -1,0 +1,88 @@
+name: Publish on tag
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. v2.1.0)'
+        required: true
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve tag
+        id: tag
+        env:
+          REF: ${{ github.ref_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          TAG="${INPUT_TAG:-$REF}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Tag '$TAG' does not match vMAJOR.MINOR.PATCH."
+            exit 1
+          fi
+          echo "tag=$TAG"             >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}"     >> "$GITHUB_OUTPUT"
+
+      - name: Checkout tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+          fetch-depth: 0
+
+      - name: Install mise
+        uses: jdx/mise-action@v2
+        with:
+          tool_versions: |
+            node 22
+
+      - name: Setup npm registry auth
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Quality gate
+        run: |
+          npm run lint
+          npm run typecheck
+          npm test
+          npm run build
+
+      - name: Verify package.json matches tag
+        env:
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          PKG=$(node -p "require('./package.json').version")
+          if [[ "$PKG" != "$VERSION" ]]; then
+            echo "::error::Tag is $VERSION but package.json is $PKG."
+            exit 1
+          fi
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --generate-notes \
+            --verify-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,136 @@
+name: Release
+
+on:
+  milestone:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      milestone:
+        description: 'Milestone title (e.g. v2.1)'
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: read
+
+jobs:
+  prepare:
+    name: Prepare release PR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve milestone title
+        id: ms
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_TITLE: ${{ github.event.milestone.title }}
+          INPUT_TITLE: ${{ inputs.milestone }}
+        run: |
+          TITLE="${EVENT_TITLE:-$INPUT_TITLE}"
+          if [[ ! "$TITLE" =~ ^v[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Milestone title '$TITLE' does not match vMAJOR.MINOR (e.g. v2.1). Skipping release."
+            exit 1
+          fi
+          VERSION="${TITLE#v}.0"
+          echo "title=$TITLE"     >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved milestone $TITLE -> version $VERSION"
+
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify milestone has no open items
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MILESTONE: ${{ steps.ms.outputs.title }}
+        run: |
+          OPEN=$(gh issue list --milestone "$MILESTONE" --state open --json number --jq 'length')
+          OPEN_PRS=$(gh pr list --search "milestone:$MILESTONE" --state open --json number --jq 'length')
+          if [[ "$OPEN" -gt 0 || "$OPEN_PRS" -gt 0 ]]; then
+            echo "::error::Milestone $MILESTONE still has $OPEN open issues and $OPEN_PRS open PRs."
+            exit 1
+          fi
+
+      - name: Install mise
+        uses: jdx/mise-action@v2
+        with:
+          tool_versions: |
+            node 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Quality gate
+        run: |
+          npm run lint
+          npm run typecheck
+          npm test
+          npm run build
+
+      - name: Pre-flight registry check
+        env:
+          VERSION: ${{ steps.ms.outputs.version }}
+        run: |
+          if npm view "op-array@$VERSION" version >/dev/null 2>&1; then
+            echo "::error::op-array@$VERSION is already published to npm."
+            exit 1
+          fi
+          echo "op-array@$VERSION is not yet on npm — proceeding."
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version and date-stamp CHANGELOG
+        env:
+          VERSION: ${{ steps.ms.outputs.version }}
+        run: |
+          npm version "$VERSION" --no-git-tag-version
+          DATE=$(date -u +%Y-%m-%d)
+          if ! grep -q "^## \[$VERSION\]$" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md is missing an unreleased '## [$VERSION]' heading."
+            exit 1
+          fi
+          sed -i "s|^## \[$VERSION\]$|## [$VERSION] - $DATE|" CHANGELOG.md
+          echo "Bumped to $VERSION and stamped CHANGELOG with $DATE."
+
+      - name: Create release branch and PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.ms.outputs.version }}
+          MILESTONE: ${{ steps.ms.outputs.title }}
+        run: |
+          BRANCH="chore/release-$VERSION"
+          git checkout -b "$BRANCH"
+          git add package.json package-lock.json CHANGELOG.md
+          git commit -m "chore(release): $VERSION"
+          git push -u origin "$BRANCH"
+
+          BODY=$(cat <<EOF
+          ## Summary
+          Automated release PR for milestone \`$MILESTONE\`. Bumps \`package.json\` to \`$VERSION\` and date-stamps the \`## [$VERSION]\` heading in \`CHANGELOG.md\`.
+
+          ## What ships next
+          On merge, \`tag-on-release-merge.yml\` will push tag \`v$VERSION\`, which fires \`publish-on-tag.yml\` to publish to npm and create the GitHub Release with auto-generated notes from this milestone's PRs.
+
+          ## Milestone PRs
+          See https://github.com/${{ github.repository }}/milestone/${{ github.event.milestone.number }}?closed=1
+          EOF
+          )
+
+          PR_URL=$(gh pr create \
+            --title "chore(release): $VERSION" \
+            --base main \
+            --head "$BRANCH" \
+            --assignee ramongr \
+            --milestone "$MILESTONE" \
+            --body "$BODY")
+
+          echo "Opened $PR_URL"
+          gh pr merge "$PR_URL" --squash --auto

--- a/.github/workflows/tag-on-release-merge.yml
+++ b/.github/workflows/tag-on-release-merge.yml
@@ -1,0 +1,46 @@
+name: Tag on release-PR merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'chore/release-')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout merge commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read version from package.json
+        id: pkg
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create and push tag
+        env:
+          VERSION: ${{ steps.pkg.outputs.version }}
+        run: |
+          TAG="v$VERSION"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "::warning::Tag $TAG already exists, skipping."
+            exit 0
+          fi
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+          echo "Pushed tag $TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.2.0]
+## [2.1.0]
 
 ### Tooling
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   notes auto-generated from the milestone's PRs. See
   `.github/workflows/release.yml`, `tag-on-release-merge.yml`, and
   `publish-on-tag.yml`.
+- Authenticated `npm publish` via npm Trusted Publishing (OIDC) inside
+  the `npm-publish` GitHub Environment — no long-lived `NPM_TOKEN`
+  stored in the repo.
 
 ## [2.0.0] - 2026-05-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0]
+
+### Tooling
+
+- Added milestone-driven release automation. Closing a `vMAJOR.MINOR`
+  milestone now opens a `chore(release): MAJOR.MINOR.0` PR (auto-merge
+  enabled) which on merge tags `vMAJOR.MINOR.0` and triggers
+  `npm publish --provenance --access public` plus a GitHub Release with
+  notes auto-generated from the milestone's PRs. See
+  `.github/workflows/release.yml`, `tag-on-release-merge.yml`, and
+  `publish-on-tag.yml`.
+
 ## [2.0.0] - 2026-05-04
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -83,6 +83,23 @@ npm run typecheck
 npm run build     # tsup -> dist/
 ```
 
+## Releasing
+
+Releases are triggered by **closing a GitHub milestone** named
+`vMAJOR.MINOR` (e.g. `v2.1`). The release workflow then:
+
+1. Verifies every issue and PR in the milestone is closed/merged and
+   the full quality gate passes.
+2. Opens a `chore(release): MAJOR.MINOR.0` PR that bumps `package.json`
+   and date-stamps the matching `CHANGELOG.md` heading. Auto-merge is
+   enabled.
+3. On PR merge, tags `vMAJOR.MINOR.0` and publishes to npm with
+   provenance, then creates a GitHub Release with notes auto-generated
+   from the milestone's merged PRs.
+
+See `.github/workflows/release.yml`, `tag-on-release-merge.yml`, and
+`publish-on-tag.yml`.
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ Releases are triggered by **closing a GitHub milestone** named
    provenance, then creates a GitHub Release with notes auto-generated
    from the milestone's merged PRs.
 
+Authentication to npm uses **npm Trusted Publishing** (OIDC) — there
+is no long-lived `NPM_TOKEN` in the repo. The publish job runs inside
+the `npm-publish` GitHub Environment, which is restricted to the `main`
+branch and (optionally) gated on a manual approval. The matching
+Trusted Publisher is registered on npmjs.com against the
+`publish-on-tag.yml` workflow with environment `npm-publish`.
+
 See `.github/workflows/release.yml`, `tag-on-release-merge.yml`, and
 `publish-on-tag.yml`.
 


### PR DESCRIPTION
## Summary
Add three GitHub Actions workflows that publish a new release when a `vMAJOR.MINOR` milestone is closed. Closing the milestone is the human "ship it" gate; everything downstream is automated. Authentication uses **npm Trusted Publishing** (OIDC) inside a `npm-publish` GitHub Environment — no long-lived `NPM_TOKEN`.

## Flow

1. **`release.yml`** — `on: milestone: closed`
   - Validates milestone title matches `^v\d+\.\d+$`, derives `MAJOR.MINOR.0`.
   - Fails if any issue or PR in the milestone is still open.
   - Runs the full quality gate (`lint`, `typecheck`, `test`, `build`).
   - Pre-flight: refuses to proceed if `op-array@VERSION` already exists on npm.
   - Bumps `package.json` (`npm version --no-git-tag-version`) and date-stamps the unreleased `## [VERSION]` heading in `CHANGELOG.md`.
   - Opens `chore/release-VERSION` PR titled `chore(release): VERSION`, assigned to `ramongr`, attached to the same milestone, with **auto-merge (squash) enabled**.
2. **`tag-on-release-merge.yml`** — `on: pull_request: closed` filtered to merged `chore/release-*` branches
   - Reads the version from `package.json` on the merge commit and pushes `vVERSION` tag.
3. **`publish-on-tag.yml`** — `on: push: tags: 'v*.*.*'`, runs in environment `npm-publish`
   - Re-runs the quality gate as defence in depth.
   - Upgrades npm to latest (Trusted Publishing requires npm >= 11.5.1; mise's Node 22 ships with npm 10.x).
   - `npm publish --provenance --access public` authenticated via OIDC; no token in the repo.
   - `gh release create vVERSION --generate-notes --verify-tag` so notes are sourced from the milestone's merged PRs.

A `workflow_dispatch` fallback is wired into `release.yml` and `publish-on-tag.yml` so you can trigger them manually from the Actions tab if anything ever goes sideways.

## Changes
- `.github/workflows/release.yml` (new)
- `.github/workflows/tag-on-release-merge.yml` (new)
- `.github/workflows/publish-on-tag.yml` (new) — uses Trusted Publishing + `npm-publish` environment, no `NPM_TOKEN`.
- `README.md`: new `## Releasing` section describing both the milestone flow and the Trusted Publishing setup.
- `CHANGELOG.md`: entry under `## [2.1.0]` -> `### Tooling`.

## Required setup before the first release

These cannot be done from a PR — you'll need to do them in the repo / npm settings:

1. **Create the GitHub Environment.** Repo Settings -> Environments -> New environment -> name `npm-publish`.
   - Deployment branches: select **Selected branches**, add `main` only.
   - Optional but recommended: enable "Required reviewers" -> add yourself; you'll click *Approve* before each publish.
   - No environment secrets needed.
2. **Register the npm Trusted Publisher.** On npmjs.com, go to the `op-array` package -> Settings -> Trusted Publishers -> Add -> GitHub Actions, then fill in:
   | Field | Value |
   |---|---|
   | Organization or user | `ramongr` |
   | Repository | `op-array` |
   | Workflow filename | `publish-on-tag.yml` |
   | Environment name | `npm-publish` |
3. **(Defer)** After the first successful Trusted Publishing release, delete any existing `NPM_TOKEN` repo secret in Settings -> Secrets and variables -> Actions. The workflow no longer references it.
4. **Branch protection.** Settings -> Branches -> `main` -> ensure "Allow auto-merge" is enabled. If required reviewers are configured, either grant `github-actions[bot]` an exemption or remove the requirement for the release PRs (they're internal automation).

## How to ship v2.1

After all v2.1 PRs (including this one) merge:
1. Go to https://github.com/ramongr/op-array/milestones
2. Click `v2.1` -> `Close milestone`
3. Watch the Actions tab — release PR opens, auto-merges, tag is pushed, npm publishes via OIDC, GitHub Release is created.

## Notes
- This PR ships in v2.1 itself so the release automation is in place to ship v2.1.
- No `Closes #<n>` link by deliberate choice — no tracking issue was created for this work.