### PR TITLE
chore(release): 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.0]
+## [2.1.0] - 2026-05-04
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "op-array",
-  "version": "2.0.0-alpha.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "op-array",
-      "version": "2.0.0-alpha.0",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-array",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Adding extra functions to the JavaScript Array",
   "homepage": "https://github.com/ramongr/op-array",
   "keywords": [
@@ -22,28 +22,64 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": { "types": "./dist/index.d.ts", "default": "./dist/index.js" },
-      "require": { "types": "./dist/index.d.cts", "default": "./dist/index.cjs" }
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./collections": {
-      "import": { "types": "./dist/collections.d.ts", "default": "./dist/collections.js" },
-      "require": { "types": "./dist/collections.d.cts", "default": "./dist/collections.cjs" }
+      "import": {
+        "types": "./dist/collections.d.ts",
+        "default": "./dist/collections.js"
+      },
+      "require": {
+        "types": "./dist/collections.d.cts",
+        "default": "./dist/collections.cjs"
+      }
     },
     "./logical": {
-      "import": { "types": "./dist/logical.d.ts", "default": "./dist/logical.js" },
-      "require": { "types": "./dist/logical.d.cts", "default": "./dist/logical.cjs" }
+      "import": {
+        "types": "./dist/logical.d.ts",
+        "default": "./dist/logical.js"
+      },
+      "require": {
+        "types": "./dist/logical.d.cts",
+        "default": "./dist/logical.cjs"
+      }
     },
     "./numerical": {
-      "import": { "types": "./dist/numerical.d.ts", "default": "./dist/numerical.js" },
-      "require": { "types": "./dist/numerical.d.cts", "default": "./dist/numerical.cjs" }
+      "import": {
+        "types": "./dist/numerical.d.ts",
+        "default": "./dist/numerical.js"
+      },
+      "require": {
+        "types": "./dist/numerical.d.cts",
+        "default": "./dist/numerical.cjs"
+      }
     },
     "./positional": {
-      "import": { "types": "./dist/positional.d.ts", "default": "./dist/positional.js" },
-      "require": { "types": "./dist/positional.d.cts", "default": "./dist/positional.cjs" }
+      "import": {
+        "types": "./dist/positional.d.ts",
+        "default": "./dist/positional.js"
+      },
+      "require": {
+        "types": "./dist/positional.d.cts",
+        "default": "./dist/positional.cjs"
+      }
     },
     "./transformations": {
-      "import": { "types": "./dist/transformations.d.ts", "default": "./dist/transformations.js" },
-      "require": { "types": "./dist/transformations.d.cts", "default": "./dist/transformations.cjs" }
+      "import": {
+        "types": "./dist/transformations.d.ts",
+        "default": "./dist/transformations.js"
+      },
+      "require": {
+        "types": "./dist/transformations.d.cts",
+        "default": "./dist/transformations.cjs"
+      }
     }
   },
   "files": [


### PR DESCRIPTION
## Summary
Automated release PR for milestone `v2.1`. Bumps `package.json` to `2.1.0` and date-stamps the `## [2.1.0]` heading in `CHANGELOG.md`.

## What ships next
On merge, `tag-on-release-merge.yml` will push tag `v2.1.0`, which fires `publish-on-tag.yml` to publish to npm and create the GitHub Release with auto-generated notes from this milestone's PRs.

## Milestone PRs
See https://github.com/ramongr/op-array/milestone/2?closed=1