### PR TITLE
feat(logical): add symmetricDifference (#26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.2.0] - Unreleased
 
+### Added
+
+- `symmetricDifference(left, right)`: items present in exactly one of
+  the two arrays (xor). Left-first then right ordering, duplicates
+  collapsed via `Set`. O(n + m).
+
 ### Tooling
 
 - Replaced ESLint + `typescript-eslint` with [oxlint](https://oxc.rs).

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ to address fields is intentional.
 | Category | Functions |
 |---|---|
 | **Collections** | `findBy`, `findById`, `where`, `extract`, `pluck`, `keyBy`, `groupBy`, `countBy` |
-| **Logical** | `intersection`, `except`, `union`, `exists`, `existsAll`, `existsAny`, `equals` |
+| **Logical** | `intersection`, `except`, `union`, `exists`, `existsAll`, `existsAny`, `equals`, `symmetricDifference` |
 | **Numerical** | `min`, `max`, `sum`, `subtract`, `product`, `average`, `hasEvenLength`, `median`, `mode` |
 | **Positional** | `first`, `second`, `third`, `last` |
 | **Transformations** | `unique`, `uniqueBy`, `flat`, `inGroups`, `inGroupsOf`, `occurrences`, `compact`, `compactNullish` |

--- a/docs/logical.md
+++ b/docs/logical.md
@@ -9,6 +9,7 @@ import {
   existsAll,
   existsAny,
   equals,
+  symmetricDifference,
 } from 'op-array/logical';
 ```
 
@@ -77,4 +78,16 @@ equals([1, 2, 3], [3, 2, 1]); // true
 equals([1, 2], [1, 2, 2]);    // true  (set semantics)
 equals([1, 2], [1, 3]);       // false
 equals([], []);               // true
+```
+
+## `symmetricDifference(left, right)`
+
+Items present in exactly one of `left` or `right` (xor). Left-first then
+right ordering; duplicates collapsed via `Set`. O(n + m).
+
+```ts
+symmetricDifference([1, 2, 3], [2, 3, 4]); // [1, 4]
+symmetricDifference([1, 1, 2], [2, 3, 3]); // [1, 3]
+symmetricDifference([1, 2], [2, 1]);       // []
+symmetricDifference([], []);               // []
 ```

--- a/src/logical/index.ts
+++ b/src/logical/index.ts
@@ -4,3 +4,4 @@ export { union } from './union.js';
 export { exists, existsAll } from './exists.js';
 export { existsAny } from './existsAny.js';
 export { equals } from './equals.js';
+export { symmetricDifference } from './symmetricDifference.js';

--- a/src/logical/symmetricDifference.ts
+++ b/src/logical/symmetricDifference.ts
@@ -1,0 +1,35 @@
+/**
+ * Returns the symmetric difference (xor) of two arrays: items present
+ * in exactly one of `left` or `right`. Order is left-first, then
+ * right; duplicates are collapsed via `Set` (SameValueZero).
+ *
+ * Runs in O(n + m).
+ *
+ * @example
+ * symmetricDifference([1, 2, 3], [2, 3, 4]); // [1, 4]
+ * symmetricDifference([1, 1, 2], [2, 3]);    // [1, 3]
+ * symmetricDifference([], []);               // []
+ */
+export function symmetricDifference<T>(
+  left: readonly T[],
+  right: readonly T[],
+): T[] {
+  const leftSet = new Set(left);
+  const rightSet = new Set(right);
+  const result: T[] = [];
+  const seen = new Set<T>();
+
+  for (const item of left) {
+    if (!rightSet.has(item) && !seen.has(item)) {
+      seen.add(item);
+      result.push(item);
+    }
+  }
+  for (const item of right) {
+    if (!leftSet.has(item) && !seen.has(item)) {
+      seen.add(item);
+      result.push(item);
+    }
+  }
+  return result;
+}

--- a/src/logical/symmetricDifference.ts
+++ b/src/logical/symmetricDifference.ts
@@ -8,6 +8,7 @@
  * @example
  * symmetricDifference([1, 2, 3], [2, 3, 4]); // [1, 4]
  * symmetricDifference([1, 1, 2], [2, 3]);    // [1, 3]
+ * symmetricDifference([1, 2], [2, 1]);       // []
  * symmetricDifference([], []);               // []
  */
 export function symmetricDifference<T>(
@@ -17,17 +18,14 @@ export function symmetricDifference<T>(
   const leftSet = new Set(left);
   const rightSet = new Set(right);
   const result: T[] = [];
-  const seen = new Set<T>();
 
-  for (const item of left) {
-    if (!rightSet.has(item) && !seen.has(item)) {
-      seen.add(item);
+  for (const item of leftSet) {
+    if (!rightSet.has(item)) {
       result.push(item);
     }
   }
-  for (const item of right) {
-    if (!leftSet.has(item) && !seen.has(item)) {
-      seen.add(item);
+  for (const item of rightSet) {
+    if (!leftSet.has(item)) {
       result.push(item);
     }
   }

--- a/tests/logical/logical.test.ts
+++ b/tests/logical/logical.test.ts
@@ -6,6 +6,7 @@ import {
   existsAll,
   existsAny,
   intersection,
+  symmetricDifference,
   union,
 } from '../../src/logical/index.js';
 
@@ -118,5 +119,43 @@ describe('equals', () => {
   test('returns false when only one side is empty', () => {
     expect(equals<number>([], [1])).toBe(false);
     expect(equals<number>([1], [])).toBe(false);
+  });
+});
+
+describe('symmetricDifference', () => {
+  test('returns items present in exactly one of the inputs', () => {
+    expect(symmetricDifference([1, 2, 3], [2, 3, 4])).toEqual([1, 4]);
+  });
+
+  test('preserves left-first then right ordering', () => {
+    expect(symmetricDifference([3, 1, 5], [4, 1, 2])).toEqual([3, 5, 4, 2]);
+  });
+
+  test('collapses duplicates within each side', () => {
+    expect(symmetricDifference([1, 1, 2], [2, 3, 3])).toEqual([1, 3]);
+  });
+
+  test('returns left when right is empty (deduped)', () => {
+    expect(symmetricDifference([1, 2, 2], [])).toEqual([1, 2]);
+  });
+
+  test('returns right when left is empty (deduped)', () => {
+    expect(symmetricDifference<number>([], [3, 3, 4])).toEqual([3, 4]);
+  });
+
+  test('returns [] for two empty arrays', () => {
+    expect(symmetricDifference<number>([], [])).toEqual([]);
+  });
+
+  test('returns [] when arrays are set-equal', () => {
+    expect(symmetricDifference([1, 2, 3], [3, 2, 1])).toEqual([]);
+  });
+
+  test('does not mutate inputs', () => {
+    const left = [1, 2, 3];
+    const right = [3, 4];
+    symmetricDifference(left, right);
+    expect(left).toEqual([1, 2, 3]);
+    expect(right).toEqual([3, 4]);
   });
 });


### PR DESCRIPTION
## Summary
Add `symmetricDifference(left, right)` to the `logical` category — returns items present in exactly one of the two arrays (xor).

## Changes
- `src/logical/symmetricDifference.ts`: implementation in O(n + m) using two `Set`s and a `seen` set to dedupe output.
- Re-exported from `src/logical/index.ts`.
- Tests in `tests/logical/logical.test.ts`: happy path, ordering (left-first then right), duplicate collapsing, both-empty → `[]`, set-equal inputs → `[]`, no-mutation contract.
- Docs added to `docs/logical.md`.
- README API table updated.
- `CHANGELOG.md` `[2.2.0]` `### Added` entry.

Closes #26