### PR TITLE
feat(logical): add isSubset (#27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `symmetricDifference(left, right)`: items present in exactly one of
   the two arrays (xor). Left-first then right ordering, duplicates
   collapsed via `Set`. O(n + m).
+- `isSubset(left, right)`: `true` when every distinct element of `left`
+  is in `right`. Empty `left` is vacuously a subset. O(n + m).
 
 ### Tooling
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ to address fields is intentional.
 | Category | Functions |
 |---|---|
 | **Collections** | `findBy`, `findById`, `where`, `extract`, `pluck`, `keyBy`, `groupBy`, `countBy` |
-| **Logical** | `intersection`, `except`, `union`, `exists`, `existsAll`, `existsAny`, `equals`, `symmetricDifference` |
+| **Logical** | `intersection`, `except`, `union`, `exists`, `existsAll`, `existsAny`, `equals`, `symmetricDifference`, `isSubset` |
 | **Numerical** | `min`, `max`, `sum`, `subtract`, `product`, `average`, `hasEvenLength`, `median`, `mode` |
 | **Positional** | `first`, `second`, `third`, `last` |
 | **Transformations** | `unique`, `uniqueBy`, `flat`, `inGroups`, `inGroupsOf`, `occurrences`, `compact`, `compactNullish` |

--- a/docs/logical.md
+++ b/docs/logical.md
@@ -10,6 +10,7 @@ import {
   existsAny,
   equals,
   symmetricDifference,
+  isSubset,
 } from 'op-array/logical';
 ```
 
@@ -90,4 +91,18 @@ symmetricDifference([1, 2, 3], [2, 3, 4]); // [1, 4]
 symmetricDifference([1, 1, 2], [2, 3, 3]); // [1, 3]
 symmetricDifference([1, 2], [2, 1]);       // []
 symmetricDifference([], []);               // []
+```
+
+## `isSubset(left, right)`
+
+`true` when every distinct element of `left` is in `right`. Empty `left`
+is vacuously a subset of any array (including `[]`). Element comparison
+uses `Set` (SameValueZero) semantics. O(n + m).
+
+```ts
+isSubset([1, 2], [1, 2, 3]); // true
+isSubset([1, 4], [1, 2, 3]); // false
+isSubset([1, 2, 3], [3, 2, 1]); // true (set-equal)
+isSubset([], [1, 2]);        // true
+isSubset([1], []);           // false
 ```

--- a/src/logical/index.ts
+++ b/src/logical/index.ts
@@ -5,3 +5,4 @@ export { exists, existsAll } from './exists.js';
 export { existsAny } from './existsAny.js';
 export { equals } from './equals.js';
 export { symmetricDifference } from './symmetricDifference.js';
+export { isSubset } from './isSubset.js';

--- a/src/logical/isSubset.ts
+++ b/src/logical/isSubset.ts
@@ -1,6 +1,7 @@
 /**
- * Returns `true` when every distinct element of `left` is present in
- * `right`. Element comparison uses `Set` (SameValueZero) semantics.
+ * Returns `true` when every element of `left` is present in `right`.
+ * Element comparison uses `Set` (SameValueZero) semantics, so
+ * duplicates in `left` collapse to a single membership check.
  *
  * Empty `left` is vacuously a subset of any array (including `[]`).
  *

--- a/src/logical/isSubset.ts
+++ b/src/logical/isSubset.ts
@@ -1,0 +1,22 @@
+/**
+ * Returns `true` when every distinct element of `left` is present in
+ * `right`. Element comparison uses `Set` (SameValueZero) semantics.
+ *
+ * Empty `left` is vacuously a subset of any array (including `[]`).
+ *
+ * Runs in O(n + m).
+ *
+ * @example
+ * isSubset([1, 2], [1, 2, 3]); // true
+ * isSubset([1, 4], [1, 2, 3]); // false
+ * isSubset([], [1, 2]);        // true
+ * isSubset([1], []);           // false
+ */
+export function isSubset<T>(left: readonly T[], right: readonly T[]): boolean {
+  if (left.length === 0) return true;
+  const rightSet = new Set(right);
+  for (const item of left) {
+    if (!rightSet.has(item)) return false;
+  }
+  return true;
+}

--- a/tests/logical/logical.test.ts
+++ b/tests/logical/logical.test.ts
@@ -6,6 +6,7 @@ import {
   existsAll,
   existsAny,
   intersection,
+  isSubset,
   symmetricDifference,
   union,
 } from '../../src/logical/index.js';
@@ -157,5 +158,40 @@ describe('symmetricDifference', () => {
     symmetricDifference(left, right);
     expect(left).toEqual([1, 2, 3]);
     expect(right).toEqual([3, 4]);
+  });
+});
+
+describe('isSubset', () => {
+  test('returns true when every element of left is in right', () => {
+    expect(isSubset([1, 2], [1, 2, 3])).toBe(true);
+  });
+
+  test('returns false when at least one element of left is missing', () => {
+    expect(isSubset([1, 4], [1, 2, 3])).toBe(false);
+  });
+
+  test('treats duplicates in left as a single membership check', () => {
+    expect(isSubset([1, 1, 2], [1, 2])).toBe(true);
+  });
+
+  test('returns true when arrays are set-equal', () => {
+    expect(isSubset([1, 2, 3], [3, 2, 1])).toBe(true);
+  });
+
+  test('returns true vacuously for empty left', () => {
+    expect(isSubset<number>([], [1, 2])).toBe(true);
+    expect(isSubset<number>([], [])).toBe(true);
+  });
+
+  test('returns false for non-empty left and empty right', () => {
+    expect(isSubset([1], [])).toBe(false);
+  });
+
+  test('does not mutate inputs', () => {
+    const left = [1, 2];
+    const right = [1, 2, 3];
+    isSubset(left, right);
+    expect(left).toEqual([1, 2]);
+    expect(right).toEqual([1, 2, 3]);
   });
 });


### PR DESCRIPTION
## Summary
Add `isSubset(left, right)` to the `logical` category — `true` when every distinct element of `left` is in `right`. Empty `left` is vacuously a subset.

## Changes
- `src/logical/isSubset.ts`: O(n + m) using a single `Set` over `right` and a short-circuit loop over `left`. Early `return true` when `left` is empty.
- Re-exported from `src/logical/index.ts`.
- Tests in `tests/logical/logical.test.ts` under a new `describe('isSubset')`: happy path, missing element, duplicate left, set-equal inputs, both empty, empty `left` only, empty `right` only, no-mutation contract.
- Docs added to `docs/logical.md`.
- README API table updated.
- `CHANGELOG.md` `[2.2.0]` `### Added` entry.

> Note: tests live in `tests/logical/logical.test.ts` (one file per category, one `describe` per function) per AGENTS.md, not the `tests/logical/isSubset.test.ts` path mentioned in the issue.

Closes #27