### PR TITLE
feat(logical): add isDisjoint (#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is in `right`. Empty `left` is vacuously a subset. O(n + m).
 - `isSuperset(left, right)`: `true` when every distinct element of
   `right` is in `left`. Any `left` is a superset of `[]`. O(n + m).
+- `isDisjoint(left, right)`: `true` when `left` and `right` share no
+  elements. Either side empty is vacuously disjoint. O(n + m).
 
 ### Tooling
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ to address fields is intentional.
 | Category | Functions |
 |---|---|
 | **Collections** | `findBy`, `findById`, `where`, `extract`, `pluck`, `keyBy`, `groupBy`, `countBy` |
-| **Logical** | `intersection`, `except`, `union`, `exists`, `existsAll`, `existsAny`, `equals`, `symmetricDifference`, `isSubset`, `isSuperset` |
+| **Logical** | `intersection`, `except`, `union`, `exists`, `existsAll`, `existsAny`, `equals`, `symmetricDifference`, `isSubset`, `isSuperset`, `isDisjoint` |
 | **Numerical** | `min`, `max`, `sum`, `subtract`, `product`, `average`, `hasEvenLength`, `median`, `mode` |
 | **Positional** | `first`, `second`, `third`, `last` |
 | **Transformations** | `unique`, `uniqueBy`, `flat`, `inGroups`, `inGroupsOf`, `occurrences`, `compact`, `compactNullish` |

--- a/docs/logical.md
+++ b/docs/logical.md
@@ -12,6 +12,7 @@ import {
   symmetricDifference,
   isSubset,
   isSuperset,
+  isDisjoint,
 } from 'op-array/logical';
 ```
 
@@ -121,4 +122,18 @@ isSuperset([1, 2, 3], [1, 4]);    // false
 isSuperset([1, 2, 3], [3, 2, 1]); // true (set-equal)
 isSuperset([1, 2], []);           // true
 isSuperset([], [1]);              // false
+```
+
+## `isDisjoint(left, right)`
+
+`true` when `left` and `right` share no elements. Either side empty is
+vacuously disjoint. Element comparison uses `Set` (SameValueZero)
+semantics. O(n + m).
+
+```ts
+isDisjoint([1, 2], [3, 4]); // true
+isDisjoint([1, 2], [2, 3]); // false
+isDisjoint([], [1, 2]);     // true
+isDisjoint([1, 2], []);     // true
+isDisjoint([], []);         // true
 ```

--- a/src/logical/index.ts
+++ b/src/logical/index.ts
@@ -7,3 +7,4 @@ export { equals } from './equals.js';
 export { symmetricDifference } from './symmetricDifference.js';
 export { isSubset } from './isSubset.js';
 export { isSuperset } from './isSuperset.js';
+export { isDisjoint } from './isDisjoint.js';

--- a/src/logical/isDisjoint.ts
+++ b/src/logical/isDisjoint.ts
@@ -1,0 +1,23 @@
+/**
+ * Returns `true` when `left` and `right` share no elements. Element
+ * comparison uses `Set` (SameValueZero) semantics.
+ *
+ * Either side empty → `true` (vacuously disjoint).
+ *
+ * Runs in O(n + m).
+ *
+ * @example
+ * isDisjoint([1, 2], [3, 4]); // true
+ * isDisjoint([1, 2], [2, 3]); // false
+ * isDisjoint([], [1, 2]);     // true
+ * isDisjoint([1, 2], []);     // true
+ */
+export function isDisjoint<T>(left: readonly T[], right: readonly T[]): boolean {
+  if (left.length === 0 || right.length === 0) return true;
+  const [smaller, larger] = left.length <= right.length ? [left, right] : [right, left];
+  const lookup = new Set(larger);
+  for (const item of smaller) {
+    if (lookup.has(item)) return false;
+  }
+  return true;
+}

--- a/tests/logical/logical.test.ts
+++ b/tests/logical/logical.test.ts
@@ -8,6 +8,7 @@ import {
   intersection,
   isSubset,
   isSuperset,
+  isDisjoint,
   symmetricDifference,
   union,
 } from '../../src/logical/index.js';
@@ -229,5 +230,45 @@ describe('isSuperset', () => {
     isSuperset(left, right);
     expect(left).toEqual([1, 2, 3]);
     expect(right).toEqual([1, 2]);
+  });
+});
+
+describe('isDisjoint', () => {
+  test('returns true when no elements overlap', () => {
+    expect(isDisjoint([1, 2], [3, 4])).toBe(true);
+  });
+
+  test('returns false when at least one element overlaps', () => {
+    expect(isDisjoint([1, 2], [2, 3])).toBe(false);
+  });
+
+  test('returns true when left is empty', () => {
+    expect(isDisjoint<number>([], [1, 2])).toBe(true);
+  });
+
+  test('returns true when right is empty', () => {
+    expect(isDisjoint<number>([1, 2], [])).toBe(true);
+  });
+
+  test('returns true for two empty arrays', () => {
+    expect(isDisjoint<number>([], [])).toBe(true);
+  });
+
+  test('returns false when arrays are set-equal', () => {
+    expect(isDisjoint([1, 2, 3], [3, 2, 1])).toBe(false);
+  });
+
+  test('handles asymmetric sizes (smaller iterated against larger lookup)', () => {
+    expect(isDisjoint([9], [1, 2, 3, 4, 5, 6, 7, 8])).toBe(true);
+    expect(isDisjoint([1, 2, 3, 4, 5, 6, 7, 8], [9])).toBe(true);
+    expect(isDisjoint([5], [1, 2, 3, 4, 5, 6, 7, 8])).toBe(false);
+  });
+
+  test('does not mutate inputs', () => {
+    const left = [1, 2];
+    const right = [3, 4];
+    isDisjoint(left, right);
+    expect(left).toEqual([1, 2]);
+    expect(right).toEqual([3, 4]);
   });
 });


### PR DESCRIPTION
## Summary
Add `isDisjoint(left, right)` to the `logical` category — `true` when the two arrays share no elements. Completes the `isSubset` / `isSuperset` / `isDisjoint` set-algebra trio.

## Changes
- `src/logical/isDisjoint.ts`: O(n + m). Builds the lookup `Set` over the larger side and iterates the smaller one for short-circuit. Either side empty → `true`.
- Re-exported from `src/logical/index.ts`.
- Tests in `tests/logical/logical.test.ts` under a new `describe('isDisjoint')`: happy path, overlap, both-sides-empty, single-side-empty, set-equal, asymmetric sizes (both orderings), no-mutation contract.
- Docs added to `docs/logical.md`.
- README API table updated.
- `CHANGELOG.md` `[2.2.0]` `### Added` entry.

> Note: tests live in `tests/logical/logical.test.ts` (one file per category, one `describe` per function) per AGENTS.md, not the `tests/logical/isDisjoint.test.ts` path mentioned in the issue.

Closes #29