### PR TITLE
feat(numerical): add range (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `right` is in `left`. Any `left` is a superset of `[]`. O(n + m).
 - `isDisjoint(left, right)`: `true` when `left` and `right` share no
   elements. Either side empty is vacuously disjoint. O(n + m).
+- `range(values)`: difference between the largest and smallest value
+  (a.k.a. extent / spread). Single pass. Throws `TypeError` on empty
+  input.
 
 ### Tooling
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ to address fields is intentional.
 |---|---|
 | **Collections** | `findBy`, `findById`, `where`, `extract`, `pluck`, `keyBy`, `groupBy`, `countBy` |
 | **Logical** | `intersection`, `except`, `union`, `exists`, `existsAll`, `existsAny`, `equals`, `symmetricDifference`, `isSubset`, `isSuperset`, `isDisjoint` |
-| **Numerical** | `min`, `max`, `sum`, `subtract`, `product`, `average`, `hasEvenLength`, `median`, `mode` |
+| **Numerical** | `min`, `max`, `sum`, `subtract`, `product`, `average`, `hasEvenLength`, `median`, `mode`, `range` |
 | **Positional** | `first`, `second`, `third`, `last` |
 | **Transformations** | `unique`, `uniqueBy`, `flat`, `inGroups`, `inGroupsOf`, `occurrences`, `compact`, `compactNullish` |
 

--- a/docs/numerical.md
+++ b/docs/numerical.md
@@ -11,6 +11,7 @@ import {
   hasEvenLength,
   median,
   mode,
+  range,
 } from 'op-array/numerical';
 ```
 
@@ -79,4 +80,15 @@ order. Returns `[]` for empty input.
 ```ts
 mode([1, 2, 2, 3]);     // [2]
 mode([1, 1, 2, 2, 3]);  // [1, 2]
+```
+
+## `range(values)`
+
+Difference between the largest and smallest value (a.k.a. extent or
+spread). Single pass. Single-element input returns `0`. **Throws
+`TypeError`** on empty input.
+
+```ts
+range([1, 5, 3, 9, 2]); // 8
+range([42]);            // 0
 ```

--- a/docs/numerical.md
+++ b/docs/numerical.md
@@ -85,8 +85,9 @@ mode([1, 1, 2, 2, 3]);  // [1, 2]
 ## `range(values)`
 
 Difference between the largest and smallest value (a.k.a. extent or
-spread). Single pass. Single-element input returns `0`. **Throws
-`TypeError`** on empty input.
+spread). Single pass. Single-element input returns `0`. Any `NaN` in
+the input propagates to the result (matches `Math.min` / `Math.max`).
+**Throws `TypeError`** on empty input.
 
 ```ts
 range([1, 5, 3, 9, 2]); // 8

--- a/src/numerical/index.ts
+++ b/src/numerical/index.ts
@@ -7,3 +7,4 @@ export { average } from './average.js';
 export { hasEvenLength } from './hasEvenLength.js';
 export { median } from './median.js';
 export { mode } from './mode.js';
+export { range } from './range.js';

--- a/src/numerical/range.ts
+++ b/src/numerical/range.ts
@@ -3,6 +3,8 @@
  * and smallest value. Computed in a single pass.
  *
  * - Single-element input returns `0`.
+ * - Propagates `NaN`: any `NaN` in the input makes the result `NaN`,
+ *   matching `min` / `max` / `Math.min` / `Math.max`.
  *
  * @throws {TypeError} when called with an empty array.
  *
@@ -16,8 +18,10 @@ export function range(values: readonly number[]): number {
   }
   let lo = values[0] as number;
   let hi = lo;
+  if (Number.isNaN(lo)) return Number.NaN;
   for (let i = 1; i < values.length; i++) {
     const v = values[i] as number;
+    if (Number.isNaN(v)) return Number.NaN;
     if (v < lo) lo = v;
     else if (v > hi) hi = v;
   }

--- a/src/numerical/range.ts
+++ b/src/numerical/range.ts
@@ -1,0 +1,25 @@
+/**
+ * Range (a.k.a. extent / spread): the difference between the largest
+ * and smallest value. Computed in a single pass.
+ *
+ * - Single-element input returns `0`.
+ *
+ * @throws {TypeError} when called with an empty array.
+ *
+ * @example
+ * range([1, 5, 3, 9, 2]); // 8
+ * range([42]);            // 0
+ */
+export function range(values: readonly number[]): number {
+  if (values.length === 0) {
+    throw new TypeError('range: array must contain at least one number');
+  }
+  let lo = values[0] as number;
+  let hi = lo;
+  for (let i = 1; i < values.length; i++) {
+    const v = values[i] as number;
+    if (v < lo) lo = v;
+    else if (v > hi) hi = v;
+  }
+  return hi - lo;
+}

--- a/tests/numerical/numerical.test.ts
+++ b/tests/numerical/numerical.test.ts
@@ -7,6 +7,7 @@ import {
   min,
   mode,
   product,
+  range,
   subtract,
   sum,
 } from '../../src/numerical/index.js';
@@ -108,5 +109,37 @@ describe('mode', () => {
 
   test('returns [] on empty input', () => {
     expect(mode<number>([])).toEqual([]);
+  });
+});
+
+describe('range', () => {
+  test('returns max minus min', () => {
+    expect(range([1, 5, 3, 9, 2])).toBe(8);
+  });
+
+  test('returns 0 for a single-element array', () => {
+    expect(range([42])).toBe(0);
+  });
+
+  test('handles negative numbers', () => {
+    expect(range([-5, -1, -3])).toBe(4);
+  });
+
+  test('handles mixed positive and negative numbers', () => {
+    expect(range([-3, 0, 7])).toBe(10);
+  });
+
+  test('returns 0 when all values are equal', () => {
+    expect(range([4, 4, 4])).toBe(0);
+  });
+
+  test('throws on empty array', () => {
+    expect(() => range([])).toThrow(TypeError);
+  });
+
+  test('does not mutate the input', () => {
+    const input = [3, 1, 2];
+    range(input);
+    expect(input).toEqual([3, 1, 2]);
   });
 });

--- a/tests/numerical/numerical.test.ts
+++ b/tests/numerical/numerical.test.ts
@@ -137,6 +137,12 @@ describe('range', () => {
     expect(() => range([])).toThrow(TypeError);
   });
 
+  test('propagates NaN (matches Math.min/Math.max)', () => {
+    expect(range([1, Number.NaN, 3])).toBeNaN();
+    expect(range([Number.NaN, 1, 2])).toBeNaN();
+    expect(range([1, 2, Number.NaN])).toBeNaN();
+  });
+
   test('does not mutate the input', () => {
     const input = [3, 1, 2];
     range(input);


### PR DESCRIPTION
## Summary
Add `range(values)` to the `numerical` category — the difference between the largest and smallest value (a.k.a. extent / spread). Throws `TypeError` on empty input, consistent with `subtract`/`product`/`median`.

## Changes
- `src/numerical/range.ts`: single-pass min/max scan (one `for` loop, no extra allocation, no `Math.min(...values)` spread). Returns `0` for single-element input.
- Re-exported from `src/numerical/index.ts`.
- Tests in `tests/numerical/numerical.test.ts` under a new `describe('range')`: happy path, single element, negatives, mixed signs, all-equal, empty throws, no-mutation.
- Docs added to `docs/numerical.md`.
- README API table updated.
- `CHANGELOG.md` `[2.2.0]` `### Added` entry.

> Note: tests live in `tests/numerical/numerical.test.ts` (one file per category, one `describe` per function) per AGENTS.md, not the `tests/numerical/range.test.ts` path mentioned in the issue.

Closes #31