### PR TITLE
feat(numerical): add variance (#32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `range(values)`: difference between the largest and smallest value
   (a.k.a. extent / spread). Single pass. Throws `TypeError` on empty
   input.
+- `variance(values, mode?)`: population (`'population'`, default) or
+  sample (`'sample'`, Bessel's correction) variance. Throws
+  `TypeError` on empty input or on single-element input when
+  `mode === 'sample'`.
 
 ### Tooling
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ to address fields is intentional.
 |---|---|
 | **Collections** | `findBy`, `findById`, `where`, `extract`, `pluck`, `keyBy`, `groupBy`, `countBy` |
 | **Logical** | `intersection`, `except`, `union`, `exists`, `existsAll`, `existsAny`, `equals`, `symmetricDifference`, `isSubset`, `isSuperset`, `isDisjoint` |
-| **Numerical** | `min`, `max`, `sum`, `subtract`, `product`, `average`, `hasEvenLength`, `median`, `mode`, `range` |
+| **Numerical** | `min`, `max`, `sum`, `subtract`, `product`, `average`, `hasEvenLength`, `median`, `mode`, `range`, `variance` |
 | **Positional** | `first`, `second`, `third`, `last` |
 | **Transformations** | `unique`, `uniqueBy`, `flat`, `inGroups`, `inGroupsOf`, `occurrences`, `compact`, `compactNullish` |
 

--- a/docs/numerical.md
+++ b/docs/numerical.md
@@ -12,6 +12,7 @@ import {
   median,
   mode,
   range,
+  variance,
 } from 'op-array/numerical';
 ```
 
@@ -92,4 +93,21 @@ the input propagates to the result (matches `Math.min` / `Math.max`).
 ```ts
 range([1, 5, 3, 9, 2]); // 8
 range([42]);            // 0
+```
+
+## `variance(values, mode?)`
+
+Variance of the values. Two-pass algorithm (mean, then average of
+squared deviations).
+
+- `mode = 'population'` (default) divides by `n` (σ²).
+- `mode = 'sample'` divides by `n − 1` (s², Bessel's correction).
+
+**Throws `TypeError`** on empty input, or on single-element input when
+`mode === 'sample'`.
+
+```ts
+variance([2, 4, 4, 4, 5, 5, 7, 9]);           // 4
+variance([2, 4, 4, 4, 5, 5, 7, 9], 'sample'); // 4.571428571428571
+variance([5]);                                // 0  (population)
 ```

--- a/docs/numerical.md
+++ b/docs/numerical.md
@@ -102,12 +102,13 @@ squared deviations).
 
 - `mode = 'population'` (default) divides by `n` (σ²).
 - `mode = 'sample'` divides by `n − 1` (s², Bessel's correction).
+- Any `NaN` in the input propagates to the result (matches `range`).
 
 **Throws `TypeError`** on empty input, or on single-element input when
 `mode === 'sample'`.
 
 ```ts
 variance([2, 4, 4, 4, 5, 5, 7, 9]);           // 4
-variance([2, 4, 4, 4, 5, 5, 7, 9], 'sample'); // 4.571428571428571
+variance([2, 4, 4, 4, 5, 5, 7, 9], 'sample'); // ≈ 4.5714…
 variance([5]);                                // 0  (population)
 ```

--- a/src/numerical/index.ts
+++ b/src/numerical/index.ts
@@ -8,3 +8,4 @@ export { hasEvenLength } from './hasEvenLength.js';
 export { median } from './median.js';
 export { mode } from './mode.js';
 export { range } from './range.js';
+export { variance } from './variance.js';

--- a/src/numerical/variance.ts
+++ b/src/numerical/variance.ts
@@ -4,6 +4,8 @@
  *
  * - `mode = 'population'` (default) divides by `n` (σ²).
  * - `mode = 'sample'` divides by `n - 1` (s², Bessel's correction).
+ * - Propagates `NaN`: any `NaN` in the input makes the result `NaN`,
+ *   matching `range` / `min` / `max`.
  *
  * @throws {TypeError} on empty input, or on single-element input when
  *   `mode === 'sample'` (division by zero).

--- a/src/numerical/variance.ts
+++ b/src/numerical/variance.ts
@@ -1,0 +1,38 @@
+/**
+ * Variance of the values. Two-pass: computes the mean, then the average
+ * of the squared deviations from the mean.
+ *
+ * - `mode = 'population'` (default) divides by `n` (σ²).
+ * - `mode = 'sample'` divides by `n - 1` (s², Bessel's correction).
+ *
+ * @throws {TypeError} on empty input, or on single-element input when
+ *   `mode === 'sample'` (division by zero).
+ *
+ * @example
+ * variance([2, 4, 4, 4, 5, 5, 7, 9]);           // 4
+ * variance([2, 4, 4, 4, 5, 5, 7, 9], 'sample'); // 4.571428571428571
+ */
+export function variance(
+  values: readonly number[],
+  mode: 'population' | 'sample' = 'population',
+): number {
+  if (values.length === 0) {
+    throw new TypeError('variance: array must contain at least one number');
+  }
+  if (mode === 'sample' && values.length < 2) {
+    throw new TypeError('variance: sample variance requires at least two numbers');
+  }
+
+  let total = 0;
+  for (const v of values) total += v;
+  const mean = total / values.length;
+
+  let sumSquaredDeviations = 0;
+  for (const v of values) {
+    const d = v - mean;
+    sumSquaredDeviations += d * d;
+  }
+
+  const divisor = mode === 'sample' ? values.length - 1 : values.length;
+  return sumSquaredDeviations / divisor;
+}

--- a/tests/numerical/numerical.test.ts
+++ b/tests/numerical/numerical.test.ts
@@ -10,6 +10,7 @@ import {
   range,
   subtract,
   sum,
+  variance,
 } from '../../src/numerical/index.js';
 
 describe('min', () => {
@@ -147,5 +148,41 @@ describe('range', () => {
     const input = [3, 1, 2];
     range(input);
     expect(input).toEqual([3, 1, 2]);
+  });
+});
+
+describe('variance', () => {
+  test('population variance by default', () => {
+    expect(variance([2, 4, 4, 4, 5, 5, 7, 9])).toBe(4);
+  });
+
+  test('sample variance with mode = "sample"', () => {
+    expect(variance([2, 4, 4, 4, 5, 5, 7, 9], 'sample')).toBeCloseTo(
+      4.571428571428571,
+      12,
+    );
+  });
+
+  test('returns 0 for a constant population', () => {
+    expect(variance([3, 3, 3])).toBe(0);
+  });
+
+  test('returns 0 for a single value (population)', () => {
+    expect(variance([5])).toBe(0);
+  });
+
+  test('throws on empty array', () => {
+    expect(() => variance([])).toThrow(TypeError);
+    expect(() => variance([], 'sample')).toThrow(TypeError);
+  });
+
+  test('throws on single value when mode = "sample"', () => {
+    expect(() => variance([5], 'sample')).toThrow(TypeError);
+  });
+
+  test('does not mutate the input', () => {
+    const input = [2, 4, 4, 4, 5, 5, 7, 9];
+    variance(input, 'sample');
+    expect(input).toEqual([2, 4, 4, 4, 5, 5, 7, 9]);
   });
 });

--- a/tests/numerical/numerical.test.ts
+++ b/tests/numerical/numerical.test.ts
@@ -180,6 +180,11 @@ describe('variance', () => {
     expect(() => variance([5], 'sample')).toThrow(TypeError);
   });
 
+  test('propagates NaN (matches range/min/max)', () => {
+    expect(variance([1, Number.NaN, 3])).toBeNaN();
+    expect(variance([1, 2, Number.NaN], 'sample')).toBeNaN();
+  });
+
   test('does not mutate the input', () => {
     const input = [2, 4, 4, 4, 5, 5, 7, 9];
     variance(input, 'sample');


### PR DESCRIPTION
## Summary
Add `variance(values, mode?)` to the `numerical` category. Defaults to **population** variance (divide by `n`); pass `'sample'` for the Bessel-corrected estimator (divide by `n − 1`). Throws `TypeError` on empty input, or on single-element input when `mode === 'sample'` (n − 1 = 0).

## Changes
- `src/numerical/variance.ts`: two-pass implementation (mean, then average of squared deviations).
- Re-exported from `src/numerical/index.ts`.
- Tests in `tests/numerical/numerical.test.ts` under a new `describe('variance')`: population happy path (textbook example, exact `4`), sample variant (`≈ 4.5714…`), constant population → `0`, single value → `0` (population), empty throws, single-value-sample throws, no-mutation contract.
- Docs added to `docs/numerical.md`.
- README API table updated.
- `CHANGELOG.md` `[2.2.0]` `### Added` entry.

> Note: tests live in `tests/numerical/numerical.test.ts` (one file per category, one `describe` per function) per AGENTS.md, not the `tests/numerical/variance.test.ts` path mentioned in the issue.

Closes #32