### PR TITLE
feat(numerical): add standardDeviation (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sample (`'sample'`, Bessel's correction) variance. Throws
   `TypeError` on empty input or on single-element input when
   `mode === 'sample'`.
+- `standardDeviation(values, mode?)`: `Math.sqrt(variance(values, mode))`.
+  Same modes and throw conditions as `variance`.
 
 ### Tooling
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ to address fields is intentional.
 |---|---|
 | **Collections** | `findBy`, `findById`, `where`, `extract`, `pluck`, `keyBy`, `groupBy`, `countBy` |
 | **Logical** | `intersection`, `except`, `union`, `exists`, `existsAll`, `existsAny`, `equals`, `symmetricDifference`, `isSubset`, `isSuperset`, `isDisjoint` |
-| **Numerical** | `min`, `max`, `sum`, `subtract`, `product`, `average`, `hasEvenLength`, `median`, `mode`, `range`, `variance` |
+| **Numerical** | `min`, `max`, `sum`, `subtract`, `product`, `average`, `hasEvenLength`, `median`, `mode`, `range`, `variance`, `standardDeviation` |
 | **Positional** | `first`, `second`, `third`, `last` |
 | **Transformations** | `unique`, `uniqueBy`, `flat`, `inGroups`, `inGroupsOf`, `occurrences`, `compact`, `compactNullish` |
 

--- a/docs/numerical.md
+++ b/docs/numerical.md
@@ -13,6 +13,7 @@ import {
   mode,
   range,
   variance,
+  standardDeviation,
 } from 'op-array/numerical';
 ```
 
@@ -111,4 +112,15 @@ squared deviations).
 variance([2, 4, 4, 4, 5, 5, 7, 9]);           // 4
 variance([2, 4, 4, 4, 5, 5, 7, 9], 'sample'); // ≈ 4.5714…
 variance([5]);                                // 0  (population)
+```
+
+## `standardDeviation(values, mode?)`
+
+Square root of `variance(values, mode)`. Same `'population'` /
+`'sample'` modes and same throw conditions. Any `NaN` in the input
+propagates to the result.
+
+```ts
+standardDeviation([2, 4, 4, 4, 5, 5, 7, 9]);           // 2
+standardDeviation([2, 4, 4, 4, 5, 5, 7, 9], 'sample'); // ≈ 2.1380…
 ```

--- a/src/numerical/index.ts
+++ b/src/numerical/index.ts
@@ -9,3 +9,4 @@ export { median } from './median.js';
 export { mode } from './mode.js';
 export { range } from './range.js';
 export { variance } from './variance.js';
+export { standardDeviation } from './standardDeviation.js';

--- a/src/numerical/standardDeviation.ts
+++ b/src/numerical/standardDeviation.ts
@@ -1,0 +1,22 @@
+import { variance } from './variance.js';
+
+/**
+ * Standard deviation: square root of `variance(values, mode)`.
+ *
+ * - `mode = 'population'` (default) → σ.
+ * - `mode = 'sample'` → s (Bessel's correction).
+ * - Propagates `NaN` (inherited from `variance`).
+ *
+ * @throws {TypeError} on empty input, or on single-element input when
+ *   `mode === 'sample'`.
+ *
+ * @example
+ * standardDeviation([2, 4, 4, 4, 5, 5, 7, 9]);           // 2
+ * standardDeviation([2, 4, 4, 4, 5, 5, 7, 9], 'sample'); // ≈ 2.1380…
+ */
+export function standardDeviation(
+  values: readonly number[],
+  mode: 'population' | 'sample' = 'population',
+): number {
+  return Math.sqrt(variance(values, mode));
+}

--- a/tests/numerical/numerical.test.ts
+++ b/tests/numerical/numerical.test.ts
@@ -8,6 +8,7 @@ import {
   mode,
   product,
   range,
+  standardDeviation,
   subtract,
   sum,
   variance,
@@ -188,6 +189,46 @@ describe('variance', () => {
   test('does not mutate the input', () => {
     const input = [2, 4, 4, 4, 5, 5, 7, 9];
     variance(input, 'sample');
+    expect(input).toEqual([2, 4, 4, 4, 5, 5, 7, 9]);
+  });
+});
+
+describe('standardDeviation', () => {
+  test('population standard deviation by default', () => {
+    expect(standardDeviation([2, 4, 4, 4, 5, 5, 7, 9])).toBe(2);
+  });
+
+  test('sample standard deviation with mode = "sample"', () => {
+    expect(standardDeviation([2, 4, 4, 4, 5, 5, 7, 9], 'sample')).toBeCloseTo(
+      Math.sqrt(32 / 7),
+      12,
+    );
+  });
+
+  test('returns 0 for a constant population', () => {
+    expect(standardDeviation([3, 3, 3])).toBe(0);
+  });
+
+  test('returns 0 for a single value (population)', () => {
+    expect(standardDeviation([5])).toBe(0);
+  });
+
+  test('throws on empty array', () => {
+    expect(() => standardDeviation([])).toThrow(TypeError);
+    expect(() => standardDeviation([], 'sample')).toThrow(TypeError);
+  });
+
+  test('throws on single value when mode = "sample"', () => {
+    expect(() => standardDeviation([5], 'sample')).toThrow(TypeError);
+  });
+
+  test('propagates NaN', () => {
+    expect(standardDeviation([1, Number.NaN, 3])).toBeNaN();
+  });
+
+  test('does not mutate the input', () => {
+    const input = [2, 4, 4, 4, 5, 5, 7, 9];
+    standardDeviation(input, 'sample');
     expect(input).toEqual([2, 4, 4, 4, 5, 5, 7, 9]);
   });
 });


### PR DESCRIPTION
## Summary
Add `standardDeviation(values, mode?)` to the `numerical` category as a thin wrapper over `Math.sqrt(variance(values, mode))`. Inherits `variance`'s `'population'` (default) / `'sample'` modes, throw conditions, and `NaN` propagation.

## Changes
- `src/numerical/standardDeviation.ts`: delegates to `variance`. Two-line body, no duplicated math.
- Re-exported from `src/numerical/index.ts`.
- Tests in `tests/numerical/numerical.test.ts` under a new `describe('standardDeviation')`: population happy path (textbook example, exact `2`), sample variant (`≈ √(32/7)`), constant population → `0`, single value → `0` (population), empty throws, single-value-sample throws, NaN propagation, no-mutation contract.
- Docs added to `docs/numerical.md`.
- README API table updated.
- `CHANGELOG.md` `[2.2.0]` `### Added` entry.

> Note: tests live in `tests/numerical/numerical.test.ts` (one file per category, one `describe` per function) per AGENTS.md, not the `tests/numerical/standardDeviation.test.ts` path mentioned in the issue.

Closes #33