### PR TITLE
feat(numerical): add quantile (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `mode === 'sample'`.
 - `standardDeviation(values, mode?)`: `Math.sqrt(variance(values, mode))`.
   Same modes and throw conditions as `variance`.
+- `quantile(values, q)`: quantile via linear interpolation between
+  adjacent ordered values (R-7 / Excel / NumPy-default). Generalises
+  `median` (`quantile(values, 0.5)`). Throws `TypeError` on empty
+  input and `RangeError` when `q` is outside `[0, 1]` or is `NaN`.
 
 ### Tooling
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ to address fields is intentional.
 |---|---|
 | **Collections** | `findBy`, `findById`, `where`, `extract`, `pluck`, `keyBy`, `groupBy`, `countBy` |
 | **Logical** | `intersection`, `except`, `union`, `exists`, `existsAll`, `existsAny`, `equals`, `symmetricDifference`, `isSubset`, `isSuperset`, `isDisjoint` |
-| **Numerical** | `min`, `max`, `sum`, `subtract`, `product`, `average`, `hasEvenLength`, `median`, `mode`, `range`, `variance`, `standardDeviation` |
+| **Numerical** | `min`, `max`, `sum`, `subtract`, `product`, `average`, `hasEvenLength`, `median`, `mode`, `range`, `variance`, `standardDeviation`, `quantile` |
 | **Positional** | `first`, `second`, `third`, `last` |
 | **Transformations** | `unique`, `uniqueBy`, `flat`, `inGroups`, `inGroupsOf`, `occurrences`, `compact`, `compactNullish` |
 

--- a/docs/numerical.md
+++ b/docs/numerical.md
@@ -14,6 +14,7 @@ import {
   range,
   variance,
   standardDeviation,
+  quantile,
 } from 'op-array/numerical';
 ```
 
@@ -123,4 +124,27 @@ propagates to the result.
 ```ts
 standardDeviation([2, 4, 4, 4, 5, 5, 7, 9]);           // 2
 standardDeviation([2, 4, 4, 4, 5, 5, 7, 9], 'sample'); // ≈ 2.1380…
+```
+
+## `quantile(values, q)`
+
+Quantile of `values` using linear interpolation between adjacent
+ordered values (the "R-7" / Excel / NumPy-default method, which
+generalises `median` so that `quantile(values, 0.5)` agrees with
+`median(values)`).
+
+- `q = 0` returns the minimum, `q = 1` the maximum.
+- Sorts numerically, does not mutate the input.
+- Any `NaN` in the input propagates to the result (matches `variance`
+  and `standardDeviation`).
+
+**Throws `TypeError`** on empty input. **Throws `RangeError`** when
+`q` is outside `[0, 1]` or is `NaN`.
+
+```ts
+quantile([1, 2, 3, 4], 0.5);  // 2.5
+quantile([1, 2, 3, 4], 0.25); // 1.75
+quantile([1, 2, 3, 4], 0.75); // 3.25
+quantile([1, 2, 3, 4], 0);    // 1
+quantile([1, 2, 3, 4], 1);    // 4
 ```

--- a/src/numerical/index.ts
+++ b/src/numerical/index.ts
@@ -10,3 +10,4 @@ export { mode } from './mode.js';
 export { range } from './range.js';
 export { variance } from './variance.js';
 export { standardDeviation } from './standardDeviation.js';
+export { quantile } from './quantile.js';

--- a/src/numerical/quantile.ts
+++ b/src/numerical/quantile.ts
@@ -23,7 +23,10 @@ export function quantile(values: readonly number[], q: number): number {
   if (values.length === 0) {
     throw new TypeError('quantile: array must contain at least one number');
   }
-  if (!(q >= 0 && q <= 1)) {
+  if (Number.isNaN(q)) {
+    throw new RangeError('quantile: q must be a number, got NaN');
+  }
+  if (q < 0 || q > 1) {
     throw new RangeError('quantile: q must be in the range [0, 1]');
   }
 

--- a/src/numerical/quantile.ts
+++ b/src/numerical/quantile.ts
@@ -1,0 +1,43 @@
+/**
+ * Quantile of the values using linear interpolation between adjacent
+ * ordered values (the "R-7" / Excel / NumPy-default method, which
+ * generalises {@link median} so that `quantile(values, 0.5)` agrees
+ * with `median(values)` for odd-length input and matches the
+ * even-length midpoint average).
+ *
+ * - `q = 0` returns the minimum, `q = 1` the maximum.
+ * - Sorts numerically without mutating the input.
+ * - Propagates `NaN`: any `NaN` in the input makes the result `NaN`,
+ *   matching `range` / `variance` / `standardDeviation`.
+ *
+ * @throws {TypeError} on empty input.
+ * @throws {RangeError} when `q` is outside `[0, 1]` or is `NaN`.
+ *
+ * @example
+ * quantile([1, 2, 3, 4], 0.5);  // 2.5
+ * quantile([1, 2, 3, 4], 0.25); // 1.75
+ * quantile([1, 2, 3, 4], 0);    // 1
+ * quantile([1, 2, 3, 4], 1);    // 4
+ */
+export function quantile(values: readonly number[], q: number): number {
+  if (values.length === 0) {
+    throw new TypeError('quantile: array must contain at least one number');
+  }
+  if (!(q >= 0 && q <= 1)) {
+    throw new RangeError('quantile: q must be in the range [0, 1]');
+  }
+
+  for (const v of values) {
+    if (Number.isNaN(v)) return Number.NaN;
+  }
+
+  const sorted = values.toSorted((a, b) => a - b);
+  const h = (sorted.length - 1) * q;
+  const i = Math.floor(h);
+  const lower = sorted[i] as number;
+
+  if (i + 1 >= sorted.length) return lower;
+
+  const upper = sorted[i + 1] as number;
+  return lower + (h - i) * (upper - lower);
+}

--- a/tests/numerical/numerical.test.ts
+++ b/tests/numerical/numerical.test.ts
@@ -7,6 +7,7 @@ import {
   min,
   mode,
   product,
+  quantile,
   range,
   standardDeviation,
   subtract,
@@ -230,5 +231,58 @@ describe('standardDeviation', () => {
     const input = [2, 4, 4, 4, 5, 5, 7, 9];
     standardDeviation(input, 'sample');
     expect(input).toEqual([2, 4, 4, 4, 5, 5, 7, 9]);
+  });
+});
+
+describe('quantile', () => {
+  test('q = 0.5 matches the median (odd length)', () => {
+    expect(quantile([3, 1, 2], 0.5)).toBe(2);
+  });
+
+  test('q = 0.5 matches the median (even length, interpolated)', () => {
+    expect(quantile([1, 2, 3, 4], 0.5)).toBe(2.5);
+  });
+
+  test('linear interpolation between adjacent ordered values', () => {
+    expect(quantile([1, 2, 3, 4], 0.25)).toBe(1.75);
+    expect(quantile([1, 2, 3, 4], 0.75)).toBe(3.25);
+  });
+
+  test('q = 0 returns the minimum, q = 1 returns the maximum', () => {
+    expect(quantile([5, 1, 9, 3], 0)).toBe(1);
+    expect(quantile([5, 1, 9, 3], 1)).toBe(9);
+  });
+
+  test('single element returns that value for any q', () => {
+    expect(quantile([42], 0)).toBe(42);
+    expect(quantile([42], 0.3)).toBe(42);
+    expect(quantile([42], 1)).toBe(42);
+  });
+
+  test('sorts numerically, not lexicographically', () => {
+    expect(quantile([10, 2, 1], 0.5)).toBe(2);
+  });
+
+  test('throws TypeError on empty input', () => {
+    expect(() => quantile([], 0.5)).toThrow(TypeError);
+  });
+
+  test('throws RangeError when q is outside [0, 1]', () => {
+    expect(() => quantile([1, 2, 3], -0.1)).toThrow(RangeError);
+    expect(() => quantile([1, 2, 3], 1.1)).toThrow(RangeError);
+  });
+
+  test('throws RangeError when q is NaN', () => {
+    expect(() => quantile([1, 2, 3], Number.NaN)).toThrow(RangeError);
+  });
+
+  test('propagates NaN in the input', () => {
+    expect(quantile([1, Number.NaN, 3], 0.5)).toBeNaN();
+  });
+
+  test('does not mutate the input', () => {
+    const input = [3, 1, 4, 1, 5, 9, 2, 6];
+    quantile(input, 0.5);
+    expect(input).toEqual([3, 1, 4, 1, 5, 9, 2, 6]);
   });
 });

--- a/tests/numerical/numerical.test.ts
+++ b/tests/numerical/numerical.test.ts
@@ -285,4 +285,12 @@ describe('quantile', () => {
     quantile(input, 0.5);
     expect(input).toEqual([3, 1, 4, 1, 5, 9, 2, 6]);
   });
+
+  test('treats -0 and 0 as equal (matches min/median signed-zero behaviour)', () => {
+    // Whichever zero ends up at index 0 after a numeric sort is engine-
+    // defined; both are valid representations of zero and compare equal.
+    expect(quantile([-0, 0], 0)).toBe(0);
+    expect(quantile([-0, 0], 1)).toBe(0);
+    expect(quantile([-0, 0], 0.5)).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

Adds `quantile(values, q)` to the numerical category, implementing
linear interpolation between adjacent ordered values (the R-7 / Excel
/ NumPy-default method). Generalises `median` so that
`quantile(values, 0.5)` matches `median(values)`.

## Changes

- `src/numerical/quantile.ts`: implementation with sort-based linear
  interpolation, `NaN` propagation, `TypeError` on empty input,
  `RangeError` on `q` outside `[0, 1]` or `NaN`.
- `src/numerical/index.ts`: re-export `quantile`.
- `tests/numerical/numerical.test.ts`: `describe('quantile')` covering
  median agreement (odd/even), interpolation, `q = 0` / `q = 1`,
  single element, numeric (not lexicographic) sort, empty throws,
  out-of-range throws, `NaN` `q`, `NaN` propagation, no-mutation.
- `docs/numerical.md`: section with examples and method note.
- `README.md`: API table updated.
- `CHANGELOG.md`: entry under `[2.2.0]` `### Added`.

100% coverage retained. Lint, typecheck, tests, build all green.

Closes #34