### PR TITLE
feat(numerical): add cumulativeSum (#35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   adjacent ordered values (R-7 / Excel / NumPy-default). Generalises
   `median` (`quantile(values, 0.5)`). Throws `TypeError` on empty
   input and `RangeError` when `q` is outside `[0, 1]` or is `NaN`.
+- `cumulativeSum(values)`: running totals. Returns an array of the
+  same length where each element is the sum of all input values up to
+  and including that index. Returns `[]` for empty input.
 
 ### Tooling
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ to address fields is intentional.
 |---|---|
 | **Collections** | `findBy`, `findById`, `where`, `extract`, `pluck`, `keyBy`, `groupBy`, `countBy` |
 | **Logical** | `intersection`, `except`, `union`, `exists`, `existsAll`, `existsAny`, `equals`, `symmetricDifference`, `isSubset`, `isSuperset`, `isDisjoint` |
-| **Numerical** | `min`, `max`, `sum`, `subtract`, `product`, `average`, `hasEvenLength`, `median`, `mode`, `range`, `variance`, `standardDeviation`, `quantile` |
+| **Numerical** | `min`, `max`, `sum`, `subtract`, `product`, `average`, `hasEvenLength`, `median`, `mode`, `range`, `variance`, `standardDeviation`, `quantile`, `cumulativeSum` |
 | **Positional** | `first`, `second`, `third`, `last` |
 | **Transformations** | `unique`, `uniqueBy`, `flat`, `inGroups`, `inGroupsOf`, `occurrences`, `compact`, `compactNullish` |
 

--- a/docs/numerical.md
+++ b/docs/numerical.md
@@ -15,6 +15,7 @@ import {
   variance,
   standardDeviation,
   quantile,
+  cumulativeSum,
 } from 'op-array/numerical';
 ```
 
@@ -147,4 +148,16 @@ quantile([1, 2, 3, 4], 0.25); // 1.75
 quantile([1, 2, 3, 4], 0.75); // 3.25
 quantile([1, 2, 3, 4], 0);    // 1
 quantile([1, 2, 3, 4], 1);    // 4
+```
+
+## `cumulativeSum(values)`
+
+Running totals: returns an array of the same length where each element
+is the sum of all input values up to and including that index. Returns
+`[]` for empty input. Any `NaN` poisons that position and every
+subsequent position.
+
+```ts
+cumulativeSum([1, 2, 3, 4]); // [1, 3, 6, 10]
+cumulativeSum([]);           // []
 ```

--- a/src/numerical/cumulativeSum.ts
+++ b/src/numerical/cumulativeSum.ts
@@ -16,8 +16,8 @@
 export function cumulativeSum(values: readonly number[]): number[] {
   const result: number[] = [];
   let running = 0;
-  for (let i = 0; i < values.length; i++) {
-    running += values[i] as number;
+  for (const v of values) {
+    running += v;
     result.push(running);
   }
   return result;

--- a/src/numerical/cumulativeSum.ts
+++ b/src/numerical/cumulativeSum.ts
@@ -1,0 +1,24 @@
+/**
+ * Running totals: returns an array of the same length where each
+ * element is the sum of all input values up to and including that
+ * index.
+ *
+ * - Empty input returns `[]` (additive identity, matches `sum`).
+ * - Output length always equals input length.
+ * - Does not mutate the input.
+ * - Any `NaN` in the input poisons that position and every subsequent
+ *   position (a direct consequence of accumulating with `+`).
+ *
+ * @example
+ * cumulativeSum([1, 2, 3, 4]); // [1, 3, 6, 10]
+ * cumulativeSum([]);           // []
+ */
+export function cumulativeSum(values: readonly number[]): number[] {
+  const result: number[] = [];
+  let running = 0;
+  for (let i = 0; i < values.length; i++) {
+    running += values[i] as number;
+    result.push(running);
+  }
+  return result;
+}

--- a/src/numerical/index.ts
+++ b/src/numerical/index.ts
@@ -11,3 +11,4 @@ export { range } from './range.js';
 export { variance } from './variance.js';
 export { standardDeviation } from './standardDeviation.js';
 export { quantile } from './quantile.js';
+export { cumulativeSum } from './cumulativeSum.js';

--- a/tests/numerical/numerical.test.ts
+++ b/tests/numerical/numerical.test.ts
@@ -330,6 +330,14 @@ describe('cumulativeSum', () => {
     expect(result[3]).toBeNaN();
   });
 
+  test('Infinity + -Infinity yields NaN at and beyond that position', () => {
+    const result = cumulativeSum([1, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, 4]);
+    expect(result[0]).toBe(1);
+    expect(result[1]).toBe(Number.POSITIVE_INFINITY);
+    expect(result[2]).toBeNaN();
+    expect(result[3]).toBeNaN();
+  });
+
   test('does not mutate the input', () => {
     const input = [1, 2, 3, 4];
     cumulativeSum(input);

--- a/tests/numerical/numerical.test.ts
+++ b/tests/numerical/numerical.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import {
   average,
+  cumulativeSum,
   hasEvenLength,
   max,
   median,
@@ -292,5 +293,46 @@ describe('quantile', () => {
     expect(quantile([-0, 0], 0)).toBe(0);
     expect(quantile([-0, 0], 1)).toBe(0);
     expect(quantile([-0, 0], 0.5)).toBe(0);
+  });
+});
+
+describe('cumulativeSum', () => {
+  test('returns running totals', () => {
+    expect(cumulativeSum([1, 2, 3, 4])).toEqual([1, 3, 6, 10]);
+  });
+
+  test('returns [] for empty input', () => {
+    expect(cumulativeSum([])).toEqual([]);
+  });
+
+  test('output length equals input length', () => {
+    expect(cumulativeSum([5]).length).toBe(1);
+    expect(cumulativeSum([1, 2, 3, 4, 5]).length).toBe(5);
+  });
+
+  test('single element returns that element wrapped', () => {
+    expect(cumulativeSum([42])).toEqual([42]);
+  });
+
+  test('handles negative numbers', () => {
+    expect(cumulativeSum([1, -2, 3, -4])).toEqual([1, -1, 2, -2]);
+  });
+
+  test('handles zeros', () => {
+    expect(cumulativeSum([0, 0, 0])).toEqual([0, 0, 0]);
+  });
+
+  test('NaN poisons the current and all subsequent positions', () => {
+    const result = cumulativeSum([1, 2, Number.NaN, 4]);
+    expect(result[0]).toBe(1);
+    expect(result[1]).toBe(3);
+    expect(result[2]).toBeNaN();
+    expect(result[3]).toBeNaN();
+  });
+
+  test('does not mutate the input', () => {
+    const input = [1, 2, 3, 4];
+    cumulativeSum(input);
+    expect(input).toEqual([1, 2, 3, 4]);
   });
 });


### PR DESCRIPTION
## Summary

Adds `cumulativeSum(values)` to the numerical category — a single-pass
running-totals helper. Returns an array of the same length where each
element is the sum of all input values up to and including that index.

## Changes

- `src/numerical/cumulativeSum.ts`: implementation. Empty input
  returns `[]` (additive identity, matches `sum`). `NaN` poisons the
  current and all subsequent positions as a natural consequence of
  `+` accumulation.
- `src/numerical/index.ts`: re-export `cumulativeSum`.
- `tests/numerical/numerical.test.ts`: `describe('cumulativeSum')`
  covering happy path, empty `→ []`, length invariant, single
  element, negatives, zeros, `NaN` poisoning, no-mutation.
- `docs/numerical.md`: section with examples.
- `README.md`: API table updated.
- `CHANGELOG.md`: entry under `[2.2.0]` `### Added`.

100% coverage retained. Lint, typecheck, tests, build all green.

Closes #35