### PR TITLE
feat(numerical): add minBy (#36)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ their category and document it.
 | Boolean predicate     | `false` (document)    | `exists`, `existsAll`, `existsAny` |
 | Map / index result    | `{}`                  | `keyBy`, `groupBy`, `countBy` |
 | Pair-of-lists result  | both empty            | `partition` -> `{ pass: [], fail: [] }` |
+| Find item by criterion | `undefined`          | `minBy`, `maxBy` |
 
 Throw `RangeError` for invalid numeric arguments (e.g. group size ≤ 0)
 and `TypeError` for empty arrays where the result is mathematically

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cumulativeSum(values)`: running totals. Returns an array of the
   same length where each element is the sum of all input values up to
   and including that index. Returns `[]` for empty input.
+- `minBy(collection, key)`: item with the smallest numeric value at
+  the dot-delimited `key`. Returns `undefined` on empty input or when
+  no item has a comparable numeric value. Items whose resolved value
+  is missing, `NaN`, or not a number are excluded; ties resolve to
+  the first occurrence.
 
 ### Tooling
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ to address fields is intentional.
 |---|---|
 | **Collections** | `findBy`, `findById`, `where`, `extract`, `pluck`, `keyBy`, `groupBy`, `countBy` |
 | **Logical** | `intersection`, `except`, `union`, `exists`, `existsAll`, `existsAny`, `equals`, `symmetricDifference`, `isSubset`, `isSuperset`, `isDisjoint` |
-| **Numerical** | `min`, `max`, `sum`, `subtract`, `product`, `average`, `hasEvenLength`, `median`, `mode`, `range`, `variance`, `standardDeviation`, `quantile`, `cumulativeSum` |
+| **Numerical** | `min`, `max`, `sum`, `subtract`, `product`, `average`, `hasEvenLength`, `median`, `mode`, `range`, `variance`, `standardDeviation`, `quantile`, `cumulativeSum`, `minBy` |
 | **Positional** | `first`, `second`, `third`, `last` |
 | **Transformations** | `unique`, `uniqueBy`, `flat`, `inGroups`, `inGroupsOf`, `occurrences`, `compact`, `compactNullish` |
 

--- a/docs/numerical.md
+++ b/docs/numerical.md
@@ -173,6 +173,12 @@ first occurrence. Items where the resolved value is missing, `NaN`,
 or not a `number` are excluded from comparison.
 
 ```ts
-minBy(products, 'price');
-minBy(users, 'profile.age');
+const products = [{ price: 9 }, { price: 3 }, { price: 7 }];
+minBy(products, 'price'); // { price: 3 }
+
+const users = [
+  { name: 'Ana', profile: { age: 30 } },
+  { name: 'Bob', profile: { age: 22 } },
+];
+minBy(users, 'profile.age'); // { name: 'Bob', profile: { age: 22 } }
 ```

--- a/docs/numerical.md
+++ b/docs/numerical.md
@@ -16,6 +16,7 @@ import {
   standardDeviation,
   quantile,
   cumulativeSum,
+  minBy,
 } from 'op-array/numerical';
 ```
 
@@ -160,4 +161,18 @@ subsequent position.
 ```ts
 cumulativeSum([1, 2, 3, 4]); // [1, 3, 6, 10]
 cumulativeSum([]);           // []
+```
+
+## `minBy(collection, key)`
+
+Returns the item with the smallest numeric value at `key`
+(dot-delimited for nested paths), or `undefined` when no item has a
+comparable numeric value. Returns the source item, not the resolved
+numeric value. Empty input returns `undefined`. Ties resolve to the
+first occurrence. Items where the resolved value is missing, `NaN`,
+or not a `number` are excluded from comparison.
+
+```ts
+minBy(products, 'price');
+minBy(users, 'profile.age');
 ```

--- a/src/numerical/index.ts
+++ b/src/numerical/index.ts
@@ -12,3 +12,4 @@ export { variance } from './variance.js';
 export { standardDeviation } from './standardDeviation.js';
 export { quantile } from './quantile.js';
 export { cumulativeSum } from './cumulativeSum.js';
+export { minBy } from './minBy.js';

--- a/src/numerical/minBy.ts
+++ b/src/numerical/minBy.ts
@@ -1,0 +1,32 @@
+import { pathResolver } from '../shared/pathResolver.js';
+
+/**
+ * Returns the item with the smallest numeric value at `key`
+ * (dot-delimited for nested paths), or `undefined` when no item has a
+ * comparable numeric value.
+ *
+ * - Empty input → `undefined`.
+ * - Items where the resolved value is missing (`undefined` / `null`),
+ *   `NaN`, or not a number are excluded from comparison.
+ * - Ties: first occurrence wins.
+ * - Returns the source item, not the resolved numeric value.
+ *
+ * @example
+ * minBy(products, 'price');
+ * minBy(users, 'profile.age');
+ */
+export function minBy<T>(collection: readonly T[], key: string): T | undefined {
+  const at = pathResolver(key);
+  let best: T | undefined;
+  let bestValue = Number.POSITIVE_INFINITY;
+
+  for (const item of collection) {
+    const v = at(item);
+    if (typeof v !== 'number' || Number.isNaN(v)) continue;
+    if (v < bestValue) {
+      bestValue = v;
+      best = item;
+    }
+  }
+  return best;
+}

--- a/tests/numerical/numerical.test.ts
+++ b/tests/numerical/numerical.test.ts
@@ -6,6 +6,7 @@ import {
   max,
   median,
   min,
+  minBy,
   mode,
   product,
   quantile,
@@ -342,5 +343,74 @@ describe('cumulativeSum', () => {
     const input = [1, 2, 3, 4];
     cumulativeSum(input);
     expect(input).toEqual([1, 2, 3, 4]);
+  });
+});
+
+describe('minBy', () => {
+  test('returns the item with the smallest value at the key', () => {
+    const items = [{ price: 9 }, { price: 3 }, { price: 7 }];
+    expect(minBy(items, 'price')).toEqual({ price: 3 });
+  });
+
+  test('resolves dot-delimited nested paths', () => {
+    const users = [
+      { name: 'Ana', profile: { age: 30 } },
+      { name: 'Bob', profile: { age: 22 } },
+      { name: 'Cid', profile: { age: 41 } },
+    ];
+    expect(minBy(users, 'profile.age')).toEqual({
+      name: 'Bob',
+      profile: { age: 22 },
+    });
+  });
+
+  test('returns undefined for empty input', () => {
+    expect(minBy([], 'price')).toBeUndefined();
+  });
+
+  test('first occurrence wins on ties', () => {
+    const items = [
+      { id: 'a', n: 5 },
+      { id: 'b', n: 1 },
+      { id: 'c', n: 1 },
+    ];
+    expect(minBy(items, 'n')).toEqual({ id: 'b', n: 1 });
+  });
+
+  test('excludes items where the path is missing', () => {
+    const items = [{ price: 5 }, { name: 'no-price' }, { price: 2 }];
+    expect(minBy(items, 'price')).toEqual({ price: 2 });
+  });
+
+  test('excludes items whose value is not a number', () => {
+    const items = [
+      { price: '3' },
+      { price: 5 },
+      { price: null },
+      { price: 2 },
+    ];
+    expect(minBy(items, 'price')).toEqual({ price: 2 });
+  });
+
+  test('excludes NaN values', () => {
+    const items = [{ n: Number.NaN }, { n: 4 }, { n: Number.NaN }];
+    expect(minBy(items, 'n')).toEqual({ n: 4 });
+  });
+
+  test('returns undefined when no item has a comparable numeric value', () => {
+    const items = [{ price: null }, { price: '3' }, {}];
+    expect(minBy(items, 'price')).toBeUndefined();
+  });
+
+  test('handles negative numbers and zero', () => {
+    const items = [{ n: -1 }, { n: 0 }, { n: -5 }, { n: 3 }];
+    expect(minBy(items, 'n')).toEqual({ n: -5 });
+  });
+
+  test('does not mutate the input', () => {
+    const items = [{ n: 3 }, { n: 1 }, { n: 2 }];
+    const snapshot = [...items];
+    minBy(items, 'n');
+    expect(items).toEqual(snapshot);
   });
 });

--- a/tests/numerical/numerical.test.ts
+++ b/tests/numerical/numerical.test.ts
@@ -382,6 +382,18 @@ describe('minBy', () => {
     expect(minBy(items, 'price')).toEqual({ price: 2 });
   });
 
+  test('excludes items where an intermediate path segment is missing', () => {
+    const items = [
+      { name: 'Ana', profile: { age: 30 } },
+      { name: 'Bob' }, // no profile at all
+      { name: 'Cid', profile: { age: 22 } },
+    ];
+    expect(minBy(items, 'profile.age')).toEqual({
+      name: 'Cid',
+      profile: { age: 22 },
+    });
+  });
+
   test('excludes items whose value is not a number', () => {
     const items = [
       { price: '3' },


### PR DESCRIPTION
## Summary

Adds `minBy(collection, key)` to the numerical category. Returns the
source item with the smallest numeric value at the dot-delimited
`key`, using `pathResolver` for path access (per the project
convention).

## Changes

- `src/numerical/minBy.ts`: single-pass implementation. Returns the
  source item, not the resolved value. Items where the resolved value
  is missing, `NaN`, or not a `number` are excluded from comparison.
  Empty input → `undefined`. Ties → first occurrence wins.
- `src/numerical/index.ts`: re-export `minBy`.
- `tests/numerical/numerical.test.ts`: `describe('minBy')` covering
  flat key, nested dot-path, empty → `undefined`, ties (first wins),
  missing path excluded, non-number excluded, `NaN` excluded, all-
  unusable → `undefined`, negatives/zero, no-mutation.
- `docs/numerical.md`: section with examples.
- `README.md`: API table updated.
- `CHANGELOG.md`: entry under `[2.2.0]` `### Added`.

100% coverage retained. Lint, typecheck, tests, build all green.

Closes #36