### PR TITLE
feat(numerical): add maxBy (#37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no item has a comparable numeric value. Items whose resolved value
   is missing, `NaN`, or not a number are excluded; ties resolve to
   the first occurrence.
+- `maxBy(collection, key)`: symmetric to `minBy` — item with the
+  largest numeric value at the dot-delimited `key`. Same exclusion
+  rules and tie-breaking.
 
 ### Tooling
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ to address fields is intentional.
 |---|---|
 | **Collections** | `findBy`, `findById`, `where`, `extract`, `pluck`, `keyBy`, `groupBy`, `countBy` |
 | **Logical** | `intersection`, `except`, `union`, `exists`, `existsAll`, `existsAny`, `equals`, `symmetricDifference`, `isSubset`, `isSuperset`, `isDisjoint` |
-| **Numerical** | `min`, `max`, `sum`, `subtract`, `product`, `average`, `hasEvenLength`, `median`, `mode`, `range`, `variance`, `standardDeviation`, `quantile`, `cumulativeSum`, `minBy` |
+| **Numerical** | `min`, `max`, `sum`, `subtract`, `product`, `average`, `hasEvenLength`, `median`, `mode`, `range`, `variance`, `standardDeviation`, `quantile`, `cumulativeSum`, `minBy`, `maxBy` |
 | **Positional** | `first`, `second`, `third`, `last` |
 | **Transformations** | `unique`, `uniqueBy`, `flat`, `inGroups`, `inGroupsOf`, `occurrences`, `compact`, `compactNullish` |
 

--- a/docs/numerical.md
+++ b/docs/numerical.md
@@ -17,6 +17,7 @@ import {
   quantile,
   cumulativeSum,
   minBy,
+  maxBy,
 } from 'op-array/numerical';
 ```
 
@@ -181,4 +182,24 @@ const users = [
   { name: 'Bob', profile: { age: 22 } },
 ];
 minBy(users, 'profile.age'); // { name: 'Bob', profile: { age: 22 } }
+```
+
+## `maxBy(collection, key)`
+
+Returns the item with the largest numeric value at `key`
+(dot-delimited for nested paths), or `undefined` when no item has a
+comparable numeric value. Returns the source item, not the resolved
+numeric value. Empty input returns `undefined`. Ties resolve to the
+first occurrence. Items where the resolved value is missing, `NaN`,
+or not a `number` are excluded from comparison.
+
+```ts
+const products = [{ price: 9 }, { price: 3 }, { price: 7 }];
+maxBy(products, 'price'); // { price: 9 }
+
+const users = [
+  { name: 'Ana', profile: { age: 30 } },
+  { name: 'Bob', profile: { age: 22 } },
+];
+maxBy(users, 'profile.age'); // { name: 'Ana', profile: { age: 30 } }
 ```

--- a/src/numerical/index.ts
+++ b/src/numerical/index.ts
@@ -13,3 +13,4 @@ export { standardDeviation } from './standardDeviation.js';
 export { quantile } from './quantile.js';
 export { cumulativeSum } from './cumulativeSum.js';
 export { minBy } from './minBy.js';
+export { maxBy } from './maxBy.js';

--- a/src/numerical/maxBy.ts
+++ b/src/numerical/maxBy.ts
@@ -1,0 +1,32 @@
+import { pathResolver } from '../shared/pathResolver.js';
+
+/**
+ * Returns the item with the largest numeric value at `key`
+ * (dot-delimited for nested paths), or `undefined` when no item has a
+ * comparable numeric value.
+ *
+ * - Empty input → `undefined`.
+ * - Items where the resolved value is missing (`undefined` / `null`),
+ *   `NaN`, or not a number are excluded from comparison.
+ * - Ties: first occurrence wins.
+ * - Returns the source item, not the resolved numeric value.
+ *
+ * @example
+ * maxBy(products, 'price');
+ * maxBy(users, 'profile.age');
+ */
+export function maxBy<T>(collection: readonly T[], key: string): T | undefined {
+  const at = pathResolver(key);
+  let best: T | undefined;
+  let bestValue = Number.NEGATIVE_INFINITY;
+
+  for (const item of collection) {
+    const v = at(item);
+    if (typeof v !== 'number' || Number.isNaN(v)) continue;
+    if (v > bestValue) {
+      bestValue = v;
+      best = item;
+    }
+  }
+  return best;
+}

--- a/tests/numerical/numerical.test.ts
+++ b/tests/numerical/numerical.test.ts
@@ -4,6 +4,7 @@ import {
   cumulativeSum,
   hasEvenLength,
   max,
+  maxBy,
   median,
   min,
   minBy,
@@ -423,6 +424,87 @@ describe('minBy', () => {
     const items = [{ n: 3 }, { n: 1 }, { n: 2 }];
     const snapshot = [...items];
     minBy(items, 'n');
+    expect(items).toEqual(snapshot);
+  });
+});
+
+describe('maxBy', () => {
+  test('returns the item with the largest value at the key', () => {
+    const items = [{ price: 9 }, { price: 3 }, { price: 7 }];
+    expect(maxBy(items, 'price')).toEqual({ price: 9 });
+  });
+
+  test('resolves dot-delimited nested paths', () => {
+    const users = [
+      { name: 'Ana', profile: { age: 30 } },
+      { name: 'Bob', profile: { age: 22 } },
+      { name: 'Cid', profile: { age: 41 } },
+    ];
+    expect(maxBy(users, 'profile.age')).toEqual({
+      name: 'Cid',
+      profile: { age: 41 },
+    });
+  });
+
+  test('returns undefined for empty input', () => {
+    expect(maxBy([], 'price')).toBeUndefined();
+  });
+
+  test('first occurrence wins on ties', () => {
+    const items = [
+      { id: 'a', n: 5 },
+      { id: 'b', n: 9 },
+      { id: 'c', n: 9 },
+    ];
+    expect(maxBy(items, 'n')).toEqual({ id: 'b', n: 9 });
+  });
+
+  test('excludes items where the path is missing', () => {
+    const items = [{ price: 5 }, { name: 'no-price' }, { price: 8 }];
+    expect(maxBy(items, 'price')).toEqual({ price: 8 });
+  });
+
+  test('excludes items where an intermediate path segment is missing', () => {
+    const items = [
+      { name: 'Ana', profile: { age: 30 } },
+      { name: 'Bob' }, // no profile at all
+      { name: 'Cid', profile: { age: 41 } },
+    ];
+    expect(maxBy(items, 'profile.age')).toEqual({
+      name: 'Cid',
+      profile: { age: 41 },
+    });
+  });
+
+  test('excludes items whose value is not a number', () => {
+    const items = [
+      { price: '99' },
+      { price: 5 },
+      { price: null },
+      { price: 8 },
+    ];
+    expect(maxBy(items, 'price')).toEqual({ price: 8 });
+  });
+
+  test('excludes NaN values', () => {
+    const items = [{ n: Number.NaN }, { n: 4 }, { n: Number.NaN }];
+    expect(maxBy(items, 'n')).toEqual({ n: 4 });
+  });
+
+  test('returns undefined when no item has a comparable numeric value', () => {
+    const items = [{ price: null }, { price: '3' }, {}];
+    expect(maxBy(items, 'price')).toBeUndefined();
+  });
+
+  test('handles negative numbers and zero', () => {
+    const items = [{ n: -5 }, { n: -1 }, { n: -10 }, { n: 0 }];
+    expect(maxBy(items, 'n')).toEqual({ n: 0 });
+  });
+
+  test('does not mutate the input', () => {
+    const items = [{ n: 3 }, { n: 9 }, { n: 2 }];
+    const snapshot = [...items];
+    maxBy(items, 'n');
     expect(items).toEqual(snapshot);
   });
 });


### PR DESCRIPTION
## Summary

Adds `maxBy(collection, key)` — symmetric counterpart to `minBy`.
Returns the source item with the largest numeric value at the
dot-delimited `key`, using `pathResolver`.

## Changes

- `src/numerical/maxBy.ts`: single-pass implementation. Same exclusion
  rules as `minBy` (missing path / non-`number` / `NaN` excluded).
  Empty input → `undefined`. Ties → first occurrence wins.
- `src/numerical/index.ts`: re-export `maxBy`.
- `tests/numerical/numerical.test.ts`: `describe('maxBy')` mirroring
  the `minBy` suite (flat key, nested dot-path, empty, ties, missing
  path, missing intermediate segment, non-number excluded, `NaN`
  excluded, all-unusable → `undefined`, negatives/zero, no-mutation).
- `docs/numerical.md`: section with self-contained literal examples.
- `README.md`: API table updated.
- `CHANGELOG.md`: entry under `[2.2.0]` `### Added`.

100% coverage retained. Lint, typecheck, tests, build all green.

Closes #37