### PR TITLE
feat(numerical): add sumBy (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `maxBy(collection, key)`: symmetric to `minBy` — item with the
   largest numeric value at the dot-delimited `key`. Same exclusion
   rules and tie-breaking.
+- `sumBy(collection, key)`: sum of the numeric values at the
+  dot-delimited `key`. Empty input returns `0` (matches `sum`).
+  Strict: throws `TypeError` if any item is missing the path or
+  resolves to a non-`number`. `NaN` propagates.
 
 ### Tooling
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ to address fields is intentional.
 |---|---|
 | **Collections** | `findBy`, `findById`, `where`, `extract`, `pluck`, `keyBy`, `groupBy`, `countBy` |
 | **Logical** | `intersection`, `except`, `union`, `exists`, `existsAll`, `existsAny`, `equals`, `symmetricDifference`, `isSubset`, `isSuperset`, `isDisjoint` |
-| **Numerical** | `min`, `max`, `sum`, `subtract`, `product`, `average`, `hasEvenLength`, `median`, `mode`, `range`, `variance`, `standardDeviation`, `quantile`, `cumulativeSum`, `minBy`, `maxBy` |
+| **Numerical** | `min`, `max`, `sum`, `subtract`, `product`, `average`, `hasEvenLength`, `median`, `mode`, `range`, `variance`, `standardDeviation`, `quantile`, `cumulativeSum`, `minBy`, `maxBy`, `sumBy` |
 | **Positional** | `first`, `second`, `third`, `last` |
 | **Transformations** | `unique`, `uniqueBy`, `flat`, `inGroups`, `inGroupsOf`, `occurrences`, `compact`, `compactNullish` |
 

--- a/docs/numerical.md
+++ b/docs/numerical.md
@@ -18,6 +18,7 @@ import {
   cumulativeSum,
   minBy,
   maxBy,
+  sumBy,
 } from 'op-array/numerical';
 ```
 
@@ -202,4 +203,21 @@ const users = [
   { name: 'Bob', profile: { age: 22 } },
 ];
 maxBy(users, 'profile.age'); // { name: 'Ana', profile: { age: 30 } }
+```
+
+## `sumBy(collection, key)`
+
+Sum of the numeric values at `key` (dot-delimited for nested paths)
+across every item in `collection`. Strict: any item where the
+resolved value is missing or not a `number` throws `TypeError`. Empty
+input returns `0` (matches `sum`). `NaN` propagates.
+
+```ts
+sumBy([{ total: 10 }, { total: 5 }], 'total'); // 15
+
+const orders = [
+  { shipping: { fee: 5 } },
+  { shipping: { fee: 7.5 } },
+];
+sumBy(orders, 'shipping.fee'); // 12.5
 ```

--- a/src/numerical/index.ts
+++ b/src/numerical/index.ts
@@ -14,3 +14,4 @@ export { quantile } from './quantile.js';
 export { cumulativeSum } from './cumulativeSum.js';
 export { minBy } from './minBy.js';
 export { maxBy } from './maxBy.js';
+export { sumBy } from './sumBy.js';

--- a/src/numerical/sumBy.ts
+++ b/src/numerical/sumBy.ts
@@ -1,0 +1,34 @@
+import { pathResolver } from '../shared/pathResolver.js';
+
+/**
+ * Sum of the numeric values at `key` (dot-delimited for nested paths)
+ * across every item in `collection`.
+ *
+ * - Empty input → `0` (additive identity, matches `sum`).
+ * - Strict: any item where the resolved value is missing or not a
+ *   `number` throws `TypeError`. Use `pluck(...).filter(...)` upstream
+ *   if you need to skip items.
+ * - `NaN` propagates: a `NaN` value yields `NaN` (matches `+`).
+ *
+ * @throws {TypeError} when an item resolves to a missing or non-numeric
+ *   value at `key`.
+ *
+ * @example
+ * sumBy([{ total: 10 }, { total: 5 }], 'total'); // 15
+ * sumBy(orders, 'shipping.fee');
+ */
+export function sumBy<T>(collection: readonly T[], key: string): number {
+  const at = pathResolver(key);
+  let total = 0;
+
+  for (const item of collection) {
+    const v = at(item);
+    if (typeof v !== 'number') {
+      throw new TypeError(
+        `sumBy: value at "${key}" is not a number (got ${v === undefined ? 'undefined' : typeof v})`,
+      );
+    }
+    total += v;
+  }
+  return total;
+}

--- a/src/numerical/sumBy.ts
+++ b/src/numerical/sumBy.ts
@@ -21,11 +21,13 @@ export function sumBy<T>(collection: readonly T[], key: string): number {
   const at = pathResolver(key);
   let total = 0;
 
-  for (const item of collection) {
-    const v = at(item);
+  for (let i = 0; i < collection.length; i++) {
+    const v = at(collection[i]);
     if (typeof v !== 'number') {
+      const kind =
+        v === null ? 'null' : v === undefined ? 'missing' : typeof v;
       throw new TypeError(
-        `sumBy: value at "${key}" is not a number (got ${v === undefined ? 'undefined' : typeof v})`,
+        `sumBy: value at "${key}" on item ${i} is not a number (${kind})`,
       );
     }
     total += v;

--- a/tests/numerical/numerical.test.ts
+++ b/tests/numerical/numerical.test.ts
@@ -539,12 +539,18 @@ describe('sumBy', () => {
   test('throws TypeError when the path is missing on any item', () => {
     expect(() =>
       sumBy([{ price: 5 }, { name: 'no-price' }], 'price'),
-    ).toThrow(TypeError);
+    ).toThrow(/missing/);
   });
 
   test('throws TypeError when the resolved value is not a number', () => {
-    expect(() => sumBy([{ price: '5' }], 'price')).toThrow(TypeError);
-    expect(() => sumBy([{ price: null }], 'price')).toThrow(TypeError);
+    expect(() => sumBy([{ price: '5' }], 'price')).toThrow(/string/);
+    expect(() => sumBy([{ price: null }], 'price')).toThrow(/null/);
+  });
+
+  test('error message reports the offending item index', () => {
+    expect(() =>
+      sumBy([{ n: 1 }, { n: 2 }, { n: '3' }, { n: 4 }], 'n'),
+    ).toThrow(/item 2/);
   });
 
   test('propagates NaN (matches +)', () => {

--- a/tests/numerical/numerical.test.ts
+++ b/tests/numerical/numerical.test.ts
@@ -15,6 +15,7 @@ import {
   standardDeviation,
   subtract,
   sum,
+  sumBy,
   variance,
 } from '../../src/numerical/index.js';
 
@@ -505,6 +506,55 @@ describe('maxBy', () => {
     const items = [{ n: 3 }, { n: 9 }, { n: 2 }];
     const snapshot = [...items];
     maxBy(items, 'n');
+    expect(items).toEqual(snapshot);
+  });
+});
+
+describe('sumBy', () => {
+  test('sums numeric values at the key', () => {
+    expect(sumBy([{ total: 10 }, { total: 5 }, { total: 3 }], 'total')).toBe(18);
+  });
+
+  test('resolves dot-delimited nested paths', () => {
+    const orders = [
+      { shipping: { fee: 5 } },
+      { shipping: { fee: 7.5 } },
+      { shipping: { fee: 2 } },
+    ];
+    expect(sumBy(orders, 'shipping.fee')).toBe(14.5);
+  });
+
+  test('returns 0 for empty input', () => {
+    expect(sumBy([], 'total')).toBe(0);
+  });
+
+  test('handles a single item', () => {
+    expect(sumBy([{ n: 42 }], 'n')).toBe(42);
+  });
+
+  test('handles negatives and zero', () => {
+    expect(sumBy([{ n: -2 }, { n: 0 }, { n: 5 }], 'n')).toBe(3);
+  });
+
+  test('throws TypeError when the path is missing on any item', () => {
+    expect(() =>
+      sumBy([{ price: 5 }, { name: 'no-price' }], 'price'),
+    ).toThrow(TypeError);
+  });
+
+  test('throws TypeError when the resolved value is not a number', () => {
+    expect(() => sumBy([{ price: '5' }], 'price')).toThrow(TypeError);
+    expect(() => sumBy([{ price: null }], 'price')).toThrow(TypeError);
+  });
+
+  test('propagates NaN (matches +)', () => {
+    expect(sumBy([{ n: 1 }, { n: Number.NaN }, { n: 3 }], 'n')).toBeNaN();
+  });
+
+  test('does not mutate the input', () => {
+    const items = [{ n: 1 }, { n: 2 }, { n: 3 }];
+    const snapshot = [...items];
+    sumBy(items, 'n');
     expect(items).toEqual(snapshot);
   });
 });


### PR DESCRIPTION
## Summary

Adds `sumBy(collection, key)` — sum of numeric values at the
dot-delimited `key` across every item. Strict contract per the issue:
missing path or non-numeric value throws `TypeError`.

## Changes

- `src/numerical/sumBy.ts`: single-pass implementation using
  `pathResolver`. Empty input → `0` (matches `sum`). Throws
  `TypeError` if any item resolves to a missing path or non-`number`
  value (the resolved type is included in the message). `NaN`
  propagates via `+`.
- `src/numerical/index.ts`: re-export `sumBy`.
- `tests/numerical/numerical.test.ts`: `describe('sumBy')` covering
  flat key, nested dot-path, empty `→ 0`, single item, negatives /
  zero, missing path throws, non-`number` throws (`'5'`, `null`),
  `NaN` propagation, no-mutation.
- `docs/numerical.md`: section with self-contained literal examples.
- `README.md`: API table updated.
- `CHANGELOG.md`: entry under `[2.2.0]` `### Added`.

100% coverage retained. Lint, typecheck, tests, build all green.

Closes #38