### PR TITLE
feat(numerical): add averageBy (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dot-delimited `key`. Empty input returns `0` (matches `sum`).
   Strict: throws `TypeError` if any item is missing the path or
   resolves to a non-`number`. `NaN` propagates.
+- `averageBy(collection, key)`: arithmetic mean of the numeric values
+  at the dot-delimited `key`. Empty input returns `NaN` (matches
+  `average`). Same strict contract as `sumBy`.
 
 ### Tooling
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ to address fields is intentional.
 |---|---|
 | **Collections** | `findBy`, `findById`, `where`, `extract`, `pluck`, `keyBy`, `groupBy`, `countBy` |
 | **Logical** | `intersection`, `except`, `union`, `exists`, `existsAll`, `existsAny`, `equals`, `symmetricDifference`, `isSubset`, `isSuperset`, `isDisjoint` |
-| **Numerical** | `min`, `max`, `sum`, `subtract`, `product`, `average`, `hasEvenLength`, `median`, `mode`, `range`, `variance`, `standardDeviation`, `quantile`, `cumulativeSum`, `minBy`, `maxBy`, `sumBy` |
+| **Numerical** | `min`, `max`, `sum`, `subtract`, `product`, `average`, `hasEvenLength`, `median`, `mode`, `range`, `variance`, `standardDeviation`, `quantile`, `cumulativeSum`, `minBy`, `maxBy`, `sumBy`, `averageBy` |
 | **Positional** | `first`, `second`, `third`, `last` |
 | **Transformations** | `unique`, `uniqueBy`, `flat`, `inGroups`, `inGroupsOf`, `occurrences`, `compact`, `compactNullish` |
 

--- a/docs/numerical.md
+++ b/docs/numerical.md
@@ -19,6 +19,7 @@ import {
   minBy,
   maxBy,
   sumBy,
+  averageBy,
 } from 'op-array/numerical';
 ```
 
@@ -220,4 +221,22 @@ const orders = [
   { shipping: { fee: 7.5 } },
 ];
 sumBy(orders, 'shipping.fee'); // 12.5
+```
+
+## `averageBy(collection, key)`
+
+Arithmetic mean of the numeric values at `key` (dot-delimited for
+nested paths) across every item in `collection`. Strict: any item
+where the resolved value is missing or not a `number` throws
+`TypeError`. Empty input returns `NaN` (matches `average`,
+consistent with `0 / 0`). `NaN` propagates.
+
+```ts
+averageBy([{ grade: 80 }, { grade: 90 }], 'grade'); // 85
+
+const users = [
+  { name: 'Ana', profile: { age: 20 } },
+  { name: 'Bob', profile: { age: 40 } },
+];
+averageBy(users, 'profile.age'); // 30
 ```

--- a/src/numerical/averageBy.ts
+++ b/src/numerical/averageBy.ts
@@ -1,0 +1,38 @@
+import { pathResolver } from '../shared/pathResolver.js';
+
+/**
+ * Arithmetic mean of the numeric values at `key` (dot-delimited for
+ * nested paths) across every item in `collection`.
+ *
+ * - Empty input → `NaN` (matches `average`, consistent with `0 / 0`).
+ * - Strict: any item where the resolved value is missing or not a
+ *   `number` throws `TypeError`. Use `pluck(...).filter(...)` upstream
+ *   if you need to skip items.
+ * - `NaN` propagates: a `NaN` value yields `NaN`.
+ *
+ * @throws {TypeError} when an item resolves to a missing or non-numeric
+ *   value at `key`.
+ *
+ * @example
+ * averageBy([{ grade: 80 }, { grade: 90 }], 'grade'); // 85
+ * averageBy(users, 'profile.age');
+ */
+export function averageBy<T>(collection: readonly T[], key: string): number {
+  if (collection.length === 0) return Number.NaN;
+
+  const at = pathResolver(key);
+  let total = 0;
+
+  for (let i = 0; i < collection.length; i++) {
+    const v = at(collection[i]);
+    if (typeof v !== 'number') {
+      const kind =
+        v === null ? 'null' : v === undefined ? 'missing' : typeof v;
+      throw new TypeError(
+        `averageBy: value at "${key}" on item ${i} is not a number (${kind})`,
+      );
+    }
+    total += v;
+  }
+  return total / collection.length;
+}

--- a/src/numerical/index.ts
+++ b/src/numerical/index.ts
@@ -15,3 +15,4 @@ export { cumulativeSum } from './cumulativeSum.js';
 export { minBy } from './minBy.js';
 export { maxBy } from './maxBy.js';
 export { sumBy } from './sumBy.js';
+export { averageBy } from './averageBy.js';

--- a/tests/numerical/numerical.test.ts
+++ b/tests/numerical/numerical.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import {
   average,
+  averageBy,
   cumulativeSum,
   hasEvenLength,
   max,
@@ -561,6 +562,61 @@ describe('sumBy', () => {
     const items = [{ n: 1 }, { n: 2 }, { n: 3 }];
     const snapshot = [...items];
     sumBy(items, 'n');
+    expect(items).toEqual(snapshot);
+  });
+});
+
+describe('averageBy', () => {
+  test('returns the arithmetic mean of values at the key', () => {
+    expect(averageBy([{ grade: 80 }, { grade: 90 }, { grade: 100 }], 'grade')).toBe(90);
+  });
+
+  test('resolves dot-delimited nested paths', () => {
+    const users = [
+      { name: 'Ana', profile: { age: 20 } },
+      { name: 'Bob', profile: { age: 30 } },
+      { name: 'Cid', profile: { age: 40 } },
+    ];
+    expect(averageBy(users, 'profile.age')).toBe(30);
+  });
+
+  test('returns NaN for empty input (matches average)', () => {
+    expect(averageBy([], 'grade')).toBeNaN();
+  });
+
+  test('handles a single item', () => {
+    expect(averageBy([{ n: 42 }], 'n')).toBe(42);
+  });
+
+  test('handles negatives and zero', () => {
+    expect(averageBy([{ n: -2 }, { n: 0 }, { n: 5 }], 'n')).toBeCloseTo(1, 12);
+  });
+
+  test('throws TypeError when the path is missing on any item', () => {
+    expect(() =>
+      averageBy([{ price: 5 }, { name: 'no-price' }], 'price'),
+    ).toThrow(/missing/);
+  });
+
+  test('throws TypeError when the resolved value is not a number', () => {
+    expect(() => averageBy([{ price: '5' }], 'price')).toThrow(/string/);
+    expect(() => averageBy([{ price: null }], 'price')).toThrow(/null/);
+  });
+
+  test('error message reports the offending item index', () => {
+    expect(() =>
+      averageBy([{ n: 1 }, { n: 2 }, { n: '3' }, { n: 4 }], 'n'),
+    ).toThrow(/item 2/);
+  });
+
+  test('propagates NaN', () => {
+    expect(averageBy([{ n: 1 }, { n: Number.NaN }, { n: 3 }], 'n')).toBeNaN();
+  });
+
+  test('does not mutate the input', () => {
+    const items = [{ n: 1 }, { n: 2 }, { n: 3 }];
+    const snapshot = [...items];
+    averageBy(items, 'n');
     expect(items).toEqual(snapshot);
   });
 });


### PR DESCRIPTION
## Summary

Adds `averageBy(collection, key)` — arithmetic mean of the numeric
values at the dot-delimited `key`. Same strict contract as `sumBy`;
empty input returns `NaN` to match `average`.

## Changes

- `src/numerical/averageBy.ts`: single-pass sum-then-divide. Uses
  `pathResolver`. Throws `TypeError` (with item index + value kind)
  on missing path or non-`number`. `NaN` propagates.
- `src/numerical/index.ts`: re-export `averageBy`.
- `tests/numerical/numerical.test.ts`: `describe('averageBy')`
  covering happy path, nested dot-path, empty `→ NaN`, single item,
  negatives/zero, missing path throws, non-number throws (`'5'`,
  `null`), error includes item index, `NaN` propagation, no-mutation.
- `docs/numerical.md`: section with self-contained literal examples.
- `README.md`: API table updated.
- `CHANGELOG.md`: entry under `[2.2.0]` `### Added`.

100% coverage retained. Lint, typecheck, tests, build all green.

Closes #39