### PR TITLE
chore(ci): harden release automation + add Node 24 to matrix (#64)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['20', '22', '24']
+        node: ['22', '24', '25']
 
     steps:
       - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
         run: npm run build
 
       - name: Upload coverage to Codecov
-        if: matrix.node == '22'
+        if: matrix.node == '24'
         uses: codecov/codecov-action@v4
         with:
           files: ./coverage/lcov.info

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['20', '22']
+        node: ['20', '22', '24']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,8 @@ jobs:
           MS_ID="${{ github.event.milestone.number }}"
           if [[ -z "$MS_ID" ]]; then
             MS_ID=$(gh api "repos/${{ github.repository }}/milestones?state=all" \
-              --jq ".[] | select(.title==\"$MILESTONE\") | .number")
+              --jq ".[] | select(.title==\"$MILESTONE\") | .number" \
+              | head -n1)
           fi
           if [[ -n "$MS_ID" ]]; then
             PR_NUMBER="${PR_URL##*/}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  issues: read
+  issues: write
 
 jobs:
   prepare:
@@ -56,11 +56,10 @@ jobs:
             exit 1
           fi
 
-      - name: Install mise
-        uses: jdx/mise-action@v2
+      - name: Install Node.js
+        uses: actions/setup-node@v4
         with:
-          tool_versions: |
-            node 22
+          node-version: 24
 
       - name: Install dependencies
         run: npm ci
@@ -117,20 +116,41 @@ jobs:
           Automated release PR for milestone \`$MILESTONE\`. Bumps \`package.json\` to \`$VERSION\` and date-stamps the \`## [$VERSION]\` heading in \`CHANGELOG.md\`.
 
           ## What ships next
-          On merge, \`tag-on-release-merge.yml\` will push tag \`v$VERSION\`, which fires \`publish-on-tag.yml\` to publish to npm and create the GitHub Release with auto-generated notes from this milestone's PRs.
+          On merge, \`tag-on-release-merge.yml\` will push tag \`v$VERSION\` and explicitly invoke \`publish-on-tag.yml\` via \`gh workflow run\`. The publish workflow then runs \`npm publish --provenance --access public\` (npm Trusted Publishing via OIDC) and creates the GitHub Release with auto-generated notes from this milestone's PRs.
 
           ## Milestone PRs
           See https://github.com/${{ github.repository }}/milestone/${{ github.event.milestone.number }}?closed=1
           EOF
           )
 
+          # Open the PR without --milestone (the milestone is already
+          # closed at this point, and `gh` only resolves OPEN milestones
+          # by title -- see issue #64).
           PR_URL=$(gh pr create \
             --title "chore(release): $VERSION" \
             --base main \
             --head "$BRANCH" \
             --assignee ramongr \
-            --milestone "$MILESTONE" \
             --body "$BODY")
 
           echo "Opened $PR_URL"
+
+          # Attach the milestone via the REST API, which accepts the
+          # numeric milestone id and works regardless of milestone state.
+          # For workflow_dispatch, look up the (potentially closed) id.
+          MS_ID="${{ github.event.milestone.number }}"
+          if [[ -z "$MS_ID" ]]; then
+            MS_ID=$(gh api "repos/${{ github.repository }}/milestones?state=all" \
+              --jq ".[] | select(.title==\"$MILESTONE\") | .number")
+          fi
+          if [[ -n "$MS_ID" ]]; then
+            PR_NUMBER="${PR_URL##*/}"
+            gh api -X PATCH \
+              "repos/${{ github.repository }}/issues/$PR_NUMBER" \
+              -F "milestone=$MS_ID" >/dev/null
+            echo "Attached PR #$PR_NUMBER to milestone $MILESTONE (id $MS_ID)."
+          else
+            echo "::warning::Could not resolve milestone id for $MILESTONE; PR left unmilestoned."
+          fi
+
           gh pr merge "$PR_URL" --squash --auto

--- a/.github/workflows/tag-on-release-merge.yml
+++ b/.github/workflows/tag-on-release-merge.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   tag:
@@ -38,9 +39,26 @@ jobs:
         run: |
           TAG="v$VERSION"
           if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "::warning::Tag $TAG already exists, skipping."
-            exit 0
+            echo "::warning::Tag $TAG already exists, skipping tag creation."
+          else
+            git tag -a "$TAG" -m "Release $TAG"
+            git push origin "$TAG"
+            echo "Pushed tag $TAG"
           fi
-          git tag -a "$TAG" -m "Release $TAG"
-          git push origin "$TAG"
-          echo "Pushed tag $TAG"
+
+      - name: Trigger publish-on-tag workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.pkg.outputs.version }}
+        run: |
+          # Tags pushed using the default GITHUB_TOKEN do NOT fire the
+          # `on: push: tags` trigger of publish-on-tag.yml (anti-
+          # recursion rule). Invoke it explicitly via workflow_dispatch
+          # so we don't need a PAT/App token. npm Trusted Publishing
+          # (OIDC) inside publish-on-tag.yml still handles registry
+          # auth.
+          TAG="v$VERSION"
+          gh workflow run publish-on-tag.yml \
+            --ref "$TAG" \
+            -f tag="$TAG"
+          echo "Dispatched publish-on-tag.yml for $TAG"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,7 @@ npm test
 npm run build
 ```
 
-Run these before pushing. CI runs the same matrix on Node 20, 22, and 24.
+Run these before pushing. CI runs the same matrix on Node 22, 24, and 25.
 
 ## Git & PR workflow
 
@@ -158,7 +158,7 @@ Run these before pushing. CI runs the same matrix on Node 20, 22, and 24.
 
 ## Tooling
 
-- Node ≥ 20 (managed via [mise](https://mise.jdx.dev), see `mise.toml`).
+- Node ≥ 22 (managed via [mise](https://mise.jdx.dev), see `mise.toml`).
 - Package manager: `npm`.
 - Build: `tsup` (dual ESM + CJS, types per entry).
 - Tests: `vitest` with v8 coverage.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,7 @@ npm test
 npm run build
 ```
 
-Run these before pushing. CI runs the same matrix on Node 20 and 22.
+Run these before pushing. CI runs the same matrix on Node 20, 22, and 24.
 
 ## Git & PR workflow
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Array.prototype.toSorted` (Node ≥20 already required at runtime).
 - CI matrix updated to Node 22 (Maintenance LTS), 24 (Active LTS),
   and 25 (Current). Node 20 dropped now that it has reached EOL.
-  `package.json` `engines.node` bumped from `>=20` to `>=22`.
 - Hardened the milestone-driven release pipeline (`release.yml`,
   `tag-on-release-merge.yml`, `publish-on-tag.yml`) so the v2.2
   release runs end-to-end without manual intervention:
@@ -85,6 +84,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Minimum supported Node version is now 22.** `package.json`
+  `engines.node` bumped from `>=20` to `>=22` now that Node 20 has
+  reached end-of-life. Consumers still on Node 20 will see an
+  `EBADENGINE` warning from npm on install.
 - `compact` uses the idiomatic `.filter(Boolean) as NonNullable<T>[]`.
 - `unique`, `union`, `occurrences` use spread instead of `Array.from`.
 - `median` uses `Array.prototype.toSorted` instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   etc.). Tests get a small relaxed override.
 - Bumped `tsconfig.json` `lib` to `ES2023` so the codebase can use
   `Array.prototype.toSorted` (Node ≥20 already required at runtime).
-- CI matrix expanded to Node 20, 22, and 24.
+- CI matrix updated to Node 22 (Maintenance LTS), 24 (Active LTS),
+  and 25 (Current). Node 20 dropped now that it has reached EOL.
+  `package.json` `engines.node` bumped from `>=20` to `>=22`.
 - Hardened the milestone-driven release pipeline (`release.yml`,
   `tag-on-release-merge.yml`, `publish-on-tag.yml`) so the v2.2
   release runs end-to-end without manual intervention:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   etc.). Tests get a small relaxed override.
 - Bumped `tsconfig.json` `lib` to `ES2023` so the codebase can use
   `Array.prototype.toSorted` (Node ≥20 already required at runtime).
+- CI matrix expanded to Node 20, 22, and 24.
+- Hardened the milestone-driven release pipeline (`release.yml`,
+  `tag-on-release-merge.yml`, `publish-on-tag.yml`) so the v2.2
+  release runs end-to-end without manual intervention:
+  - `release.yml` attaches the release PR to its (already-closed)
+    milestone via the REST API, after `gh pr create` (which only
+    resolves open milestones by title).
+  - `release.yml` switched from `mise` + Node 22 to `actions/setup-
+    node@v4` Node 24, matching `publish-on-tag.yml` and avoiding the
+    broken bundled npm in older Node 22.x.x images.
+  - `tag-on-release-merge.yml` now explicitly invokes
+    `publish-on-tag.yml` via `gh workflow run` after pushing the
+    tag (tags pushed using `GITHUB_TOKEN` cannot fire downstream
+    `on: push: tags` triggers — anti-recursion rule). No PAT or
+    GitHub App token required; npm Trusted Publishing via OIDC
+    still handles registry auth.
+  - Added `docs/release.md` documenting the pipeline contracts and
+    manual recovery paths for each stage.
 
 ### Changed
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,110 @@
+# Release process
+
+This repo ships through a milestone-driven pipeline. The happy path is
+**close the milestone, walk away.** This document covers what runs
+automatically, the boundary contracts between the workflows, and the
+manual recovery paths if any link in the chain breaks.
+
+## Pipeline overview
+
+```
+  v2.x milestone closed
+          │
+          ▼
+  release.yml ─────────────────────────────► chore/release-2.x.0 PR
+          │                                   (auto-merge enabled)
+          │  bumps package.json + dates
+          │  CHANGELOG, runs quality gate
+          │
+          ▼
+  PR merges to main
+          │
+          ▼
+  tag-on-release-merge.yml ───────────────► v2.x.0 tag pushed
+          │                                  + workflow_dispatch on
+          │                                  publish-on-tag.yml
+          ▼
+  publish-on-tag.yml
+          │  quality gate, version sanity check
+          │  npm publish --provenance (OIDC, no NPM_TOKEN)
+          │  gh release create --generate-notes
+          ▼
+  Published to npm + GitHub Release
+```
+
+## Workflows
+
+### `.github/workflows/release.yml`
+
+- **Trigger:** `milestone: closed` (auto) or `workflow_dispatch` with a
+  `milestone` input.
+- **Output:** opens `chore/release-<VERSION>` PR against `main`,
+  attached to the originating milestone, with auto-merge enabled.
+- **Node:** 24 via `actions/setup-node@v4` (matches `publish-on-tag`).
+- **Milestone attachment:** PR is created without `--milestone`
+  (the milestone is already closed by the time this runs, and
+  `gh pr create --milestone` only resolves *open* milestones by
+  title), then attached via `gh api -X PATCH .../issues/<PR> -F
+  milestone=<id>`.
+
+### `.github/workflows/tag-on-release-merge.yml`
+
+- **Trigger:** any merged PR whose head branch starts with
+  `chore/release-`.
+- **Behaviour:** reads the version from `package.json`, pushes
+  `v<VERSION>`, then explicitly dispatches `publish-on-tag.yml` via
+  `gh workflow run`.
+- **Why the explicit dispatch:** GitHub's anti-recursion rule means
+  tags pushed using the default `GITHUB_TOKEN` do **not** fire the
+  `on: push: tags` trigger of another workflow. Rather than introduce
+  a PAT or GitHub App token, this workflow invokes the publish
+  workflow directly (it already supports `workflow_dispatch` with a
+  `tag` input). npm Trusted Publishing via OIDC handles the actual
+  registry authentication on the publish side.
+- **Permissions:** needs `contents: write` (push tag) + `actions:
+  write` (dispatch the publish workflow).
+
+### `.github/workflows/publish-on-tag.yml`
+
+- **Trigger:** `push: tags: [v*.*.*]` (when a human pushes a tag) or
+  `workflow_dispatch` with a `tag` input (when invoked by
+  `tag-on-release-merge.yml`).
+- **Auth:** npm Trusted Publishing via OIDC (`id-token: write`,
+  `environment: npm-publish`). No long-lived `NPM_TOKEN` stored in the
+  repo.
+- **Node:** 24 via `actions/setup-node@v4` (npm 11.x ships with Node
+  24, which is the minimum for Trusted Publishing).
+
+## Manual recovery
+
+If the chain breaks midway, fire the next stage manually with
+`workflow_dispatch`. All downstream steps are idempotent.
+
+| If the failure is at...                     | Recover with                                               |
+|---------------------------------------------|------------------------------------------------------------|
+| `release.yml` (PR not opened or unmilestoned) | `gh workflow run release.yml -f milestone=v2.x`            |
+| `tag-on-release-merge.yml` (tag not pushed)   | `git tag -a v2.x.0 -m "Release v2.x.0" && git push origin v2.x.0` from `main` at the merged release commit |
+| Publish not invoked after tag push            | `gh workflow run publish-on-tag.yml -f tag=v2.x.0`         |
+| Publish ran but failed mid-flight             | Fix the root cause, then re-run: `gh workflow run publish-on-tag.yml -f tag=v2.x.0` |
+
+`publish-on-tag.yml` will refuse to publish if `op-array@<VERSION>` is
+already on npm (the `npm view` pre-flight check), so re-running after
+a successful publish is safe — it will simply error out at the
+sanity check.
+
+## Versioning rules
+
+- Milestone titles must match `vMAJOR.MINOR` (e.g. `v2.2`).
+- The minor version closes as `MAJOR.MINOR.0`. Patch releases are
+  ad-hoc and not yet automated; cut them by manually bumping
+  `package.json`, opening a `chore/release-MAJOR.MINOR.PATCH` PR, and
+  letting `tag-on-release-merge.yml` take over.
+- `CHANGELOG.md` must contain an unreleased `## [MAJOR.MINOR.0]`
+  heading before `release.yml` runs; the workflow date-stamps it in
+  place.
+
+## Out of scope
+
+- `dist-tag` branching (`latest` vs `next`): a v3-era concern.
+- Migrating the broader CI (`main.yml`) off mise: only the release-time
+  workflows need to be on the npm-Trusted-Publishing-compatible Node.

--- a/docs/release.md
+++ b/docs/release.md
@@ -92,6 +92,15 @@ already on npm (the `npm view` pre-flight check), so re-running after
 a successful publish is safe — it will simply error out at the
 sanity check.
 
+> **Re-merging a release branch.** If a release PR is reverted and
+> re-merged, `tag-on-release-merge.yml` will fall through to the
+> publish dispatch even when the tag already exists. The dispatch
+> uses `--ref "$TAG"`, so publish runs against the **existing tag's
+> tree**, not the new merge commit. If the re-merge introduced new
+> code that should be published, delete the tag (`git push --delete
+> origin v2.x.0 && git tag -d v2.x.0`) before re-merging so the
+> workflow re-creates it at the new commit.
+
 ## Versioning rules
 
 - Milestone titles must match `vMAJOR.MINOR` (e.g. `v2.2`).

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "prepublishOnly": "npm run lint && npm run typecheck && npm test && npm run build"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "devDependencies": {
     "@types/node": "^22.7.0",


### PR DESCRIPTION
## Summary

Hardens the milestone-driven release pipeline so the v2.2 release runs
end-to-end without the three manual interventions that were needed
during v2.1.0. Also refreshes the CI Node matrix.

## Changes

### `release.yml` (AC #1, AC #3)

- Drop `--milestone "$MILESTONE"` from `gh pr create` — that path
  fails with `'v2.x' not found` because the milestone is already
  closed by the time the workflow runs and `gh` only resolves *open*
  milestones by title.
- After opening the PR, attach the milestone via the REST API:
  `gh api -X PATCH .../issues/<PR> -F milestone=<id>`. The id comes
  from `github.event.milestone.number` for the `milestone: closed`
  trigger, with a fallback `gh api .../milestones?state=all` lookup
  (hardened with `head -n1`) for `workflow_dispatch`.
- Switch from `mise` + Node 22 to `actions/setup-node@v4` Node 24,
  matching `publish-on-tag.yml` and avoiding the broken bundled npm
  in older Node 22.x images.
- Added `issues: write` permission (needed for the milestone PATCH).

### `tag-on-release-merge.yml` (AC #2)

- After pushing the tag, explicitly dispatch `publish-on-tag.yml` via
  `gh workflow run --ref "$TAG" -f tag="$TAG"`. Tags pushed using
  `GITHUB_TOKEN` cannot fire `on: push: tags` triggers (GitHub's
  anti-recursion rule), so the publish workflow was never being
  invoked automatically.
- This sidesteps the need for a PAT or GitHub App token — `npm
  publish` itself still uses Trusted Publishing via OIDC (`id-token:
  write` + `environment: npm-publish`), unchanged.
- Added `actions: write` permission (needed for `workflow run`).
- Tag-already-exists path now still falls through to dispatch
  (idempotent re-runs); re-merge caveat documented in
  `docs/release.md`.

### `docs/release.md` (AC #4)

New file documenting:
- Pipeline overview (ASCII flow).
- Per-workflow contracts (triggers, outputs, permissions, the
  rationale for each non-obvious choice).
- Manual recovery table — which `workflow_dispatch` to fire if the
  chain breaks at each stage, plus the re-merge / tag-already-exists
  caveat.
- Versioning rules and out-of-scope concerns.

### CI matrix

- `main.yml`: matrix is now Node **22, 24, 25** (Node 20 dropped now
  that it has reached EOL; Node 25 added as Current). Codecov upload
  moved to Node 24.
- `package.json` `engines.node` bumped from `>=20` to `>=22`.
- `AGENTS.md`: matrix and Node-version references updated.

### CHANGELOG

- Engines bump promoted to `### Changed` (consumer-visible — npm
  emits `EBADENGINE` for users still on Node 20).
- Pipeline hardening + matrix change summarised under `### Tooling`.

Closes #64