### PR TITLE
fix(ci): accept '- Unreleased' suffix in release.yml validator (#80)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,11 +92,11 @@ jobs:
         run: |
           npm version "$VERSION" --no-git-tag-version
           DATE=$(date -u +%Y-%m-%d)
-          if ! grep -q "^## \[$VERSION\]$" CHANGELOG.md; then
+          if ! grep -qE "^## \[$VERSION\]( - Unreleased)?$" CHANGELOG.md; then
             echo "::error::CHANGELOG.md is missing an unreleased '## [$VERSION]' heading."
             exit 1
           fi
-          sed -i "s|^## \[$VERSION\]$|## [$VERSION] - $DATE|" CHANGELOG.md
+          sed -i -E "s|^## \[$VERSION\]( - Unreleased)?$|## [$VERSION] - $DATE|" CHANGELOG.md
           echo "Bumped to $VERSION and stamped CHANGELOG with $DATE."
 
       - name: Create release branch and PR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Tooling
 
+- `release.yml` CHANGELOG-heading validator now accepts the
+  Keep-a-Changelog `## [VERSION] - Unreleased` form (previously only
+  bare `## [VERSION]` was accepted, causing the v2.2 release run to
+  fail at the date-stamp step).
 - Replaced ESLint + `typescript-eslint` with [oxlint](https://oxc.rs).
   Lint config moved from `eslint.config.js` to `.oxlintrc.json`. The
   rule set was tightened: `correctness`, `suspicious`, and `perf`


### PR DESCRIPTION
## Summary

The release pipeline that we just hardened in #79 still bails out on
the v2.2 release because its CHANGELOG-heading validator only accepts
the bare form `## [VERSION]`, while our `CHANGELOG.md` (and the
Keep-a-Changelog convention documented in `docs/release.md`) uses
`## [VERSION] - Unreleased`.

## Changes

- `release.yml`: switch the `grep` and `sed` to extended regex with an
  optional ` - Unreleased` suffix.
- `CHANGELOG.md`: note the fix under `[2.2.0]` `### Tooling`.

## Repro

The v2.2 milestone close fired run
[25405956610](https://github.com/ramongr/op-array/actions/runs/25405956610)
which failed at the date-stamp step with:

> CHANGELOG.md is missing an unreleased '## [2.2.0]' heading.

After this PR merges, re-close the v2.2 milestone (open then close) to
re-trigger `release.yml`.

Closes #80