### PR TITLE
chore(v3): amend AGENTS.md for v3 conventions (#86)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,16 @@ Conventions for any human or agent contributing to **op-array**. Read this
 before opening a PR. Everything below is enforced by review or by
 `npm run lint && npm run typecheck && npm test && npm run build`.
 
+> **v3 is in progress.** The conventions below describe the **v3 target
+> state** (data-first + options-object calling convention, dot-paths
+> everywhere, ESM-only). v2.x is in **patch-only mode**: bug-fix PRs that
+> ship as `2.x.y` keep v2.x's existing positional API and dual ESM+CJS
+> build untouched. Roadmaps:
+> [v3.0](https://github.com/ramongr/op-array/issues/86)
+> · [v3.1](https://github.com/ramongr/op-array/issues/87)
+> · [v3.2](https://github.com/ramongr/op-array/issues/88)
+> · [v3.3](https://github.com/ramongr/op-array/issues/89).
+
 ## Project layout
 
 ```
@@ -26,6 +36,64 @@ Categories: `collections`, `logical`, `numerical`, `positional`,
 `transformations`. Each category is also published as a subpath
 (`op-array/collections`, etc.); keep the category boundary intentional.
 
+## Calling convention
+
+Every function uses **data-first + options-object**:
+
+- The **first positional argument is the primary data** — the array (or
+  arrays) being operated on.
+- **Every subsequent argument folds into a single options object** with
+  named fields. No second/third/Nth positional argument.
+- Single-argument functions stay positional (`sum(values)`,
+  `unique(values)`, `first(values)`).
+
+```ts
+findBy(users, { key: 'profile.email', value: 'a@b' });
+groupBy(orders, { key: 'customer' });
+quantile(values, { q: 0.95 });
+flat(values, { depth: 2 });
+nth(values, { index: -1 });
+variance(values, { mode: 'sample' });
+```
+
+### Carve-out for pure-data multi-array functions
+
+Functions whose multiple arguments are all **primary data of equal
+status** keep them positional. There is no options object. This applies
+to:
+
+- Set operations: `intersection`, `union`, `except`,
+  `symmetricDifference`, `setEquals`, `isSubset`, `isSuperset`,
+  `isDisjoint`.
+- Membership predicates: `exists`, `existsAll`, `existsAny`.
+- Pair helpers: `zip` (the second array is data, not config).
+
+```ts
+intersection(left, right);
+isSubset(left, right);
+existsAll(source, items);
+```
+
+### Per-function `Options` type
+
+Every multi-arg function exports a named options type alongside it,
+formed as `<FunctionName>Options`:
+
+```ts
+export type FindByOptions<T, P extends Paths<T>> = {
+  key: P;
+  value: Get<T, P>;
+};
+
+export function findBy<T, P extends Paths<T>>(
+  collection: readonly T[],
+  options: FindByOptions<T, P>,
+): T | undefined { … }
+```
+
+Both the function and its options type are re-exported from the
+category index.
+
 ## Code style
 
 - **Named `export function`** declarations only. No default exports, no
@@ -46,28 +114,37 @@ Categories: `collections`, `logical`, `numerical`, `positional`,
 Match the v2.0 precedent. New functions must pick the option that fits
 their category and document it.
 
-| Operation kind        | Empty input           | Examples            |
-|-----------------------|-----------------------|---------------------|
-| Additive aggregate    | identity (`0`)        | `sum`               |
-| Multiplicative / fold | `TypeError`           | `product`, `subtract`, `median` |
-| Statistical mean      | `NaN`                 | `average`           |
-| Set / list result     | `[]`                  | `mode`, `unique`, `intersection`, `pluck` |
-| Boolean predicate     | `false` (document)    | `exists`, `existsAll`, `existsAny` |
-| Map / index result    | `{}`                  | `keyBy`, `groupBy`, `countBy` |
-| Pair-of-lists result  | both empty            | `partition` -> `{ pass: [], fail: [] }` |
-| Find item by criterion | `undefined`          | `minBy`, `maxBy` |
+| Operation kind         | Empty input          | Examples            |
+|------------------------|----------------------|---------------------|
+| Additive aggregate     | identity (`0`)       | `sum`, `cumulativeSum` (returns `[]`) |
+| Multiplicative / fold  | `TypeError`          | `product`, `subtract`, `median`, `min`, `max`, `range`, `variance`, `standardDeviation`, `quantile` |
+| Statistical mean       | `NaN`                | `average`, `averageBy` |
+| Set / list result      | `[]`                 | `mode`, `unique`, `uniqueBy`, `pluck`, `compactNullish`, `compactFalsy`, `flat`, `intersection`, `union`, `except`, `symmetricDifference` |
+| Membership predicate   | `false` (empty source) | `exists`, `existsAny` |
+| Set-theoretic predicate | follow vacuous truth | `existsAll(_, [])` → `true`; `isSubset([], _)` → `true`; `isSuperset(_, [])` → `true`; `isDisjoint(_, [])` → `true`; `setEquals([], [])` → `true` |
+| Map / index result     | `{}` or `Map()`      | `keyBy`, `groupBy`, `countBy`, `occurrences` (returns `Map()`) |
+| Pair-of-lists result   | both empty           | `partition` -> `{ pass: [], fail: [] }` |
+| Find item by criterion | `undefined`          | `findBy`, `where` (returns `[]`), `first`, `last`, `nth`, `minBy`, `maxBy` |
 
-Throw `RangeError` for invalid numeric arguments (e.g. group size ≤ 0)
-and `TypeError` for empty arrays where the result is mathematically
-undefined.
+Throw `RangeError` for invalid numeric arguments (e.g. group size ≤ 0,
+quantile `q` outside `[0, 1]`) and `TypeError` for empty arrays where
+the result is mathematically undefined.
 
 ### Dot-path key access
 
-Any function that takes a `key: string` argument resolves it as a
-dot-delimited path through `src/shared/pathResolver.ts` (which delegates
-to `nestedObjectValue`). This is the single, consistent way to address
-nested fields across the API. Never accept a callback as an alternative
-overload.
+All key and path access in the public API uses dot-delimited paths,
+resolved through `src/shared/pathResolver.ts` (which delegates to
+`nestedObjectValue`). This is the single, consistent way to address
+nested fields. There are no shallow-key overloads, no `keyof T`-typed
+shortcuts, and no callback alternatives.
+
+This applies to:
+
+- single-key fields on options objects: `key: 'profile.email'`,
+- multi-key fields: `paths: ['user.name', 'contact.email']` (e.g. on
+  `extract`),
+- typed via the shared `Paths<T>` helper, with results inferred via
+  `Get<T, P>`.
 
 ```ts
 import { pathResolver } from '../shared/pathResolver.js';
@@ -99,9 +176,12 @@ function must update **all three** of:
    runnable example. Keep the same heading shape as siblings:
    `## ` + `` `name(arg, arg)` ``.
 2. `README.md` — the **API overview** table.
-3. `CHANGELOG.md` — an entry under `## [2.1.0]` (Keep a Changelog
+3. `CHANGELOG.md` — an entry under `## [Unreleased]` (Keep a Changelog
    format). Group entries under `### Added`, `### Changed`,
-   `### Fixed`, `### Tooling`.
+   `### Removed`, `### Fixed`, `### Tooling`. Breaking-change PRs
+   targeting the `v3.0` milestone must also include a **Migration**
+   section in the PR body — these get aggregated into `MIGRATION-v3.md`
+   before tagging `3.0.0`.
 
 Internal-only changes (under `src/shared/`) only need the `CHANGELOG`
 entry under `### Tooling` or no entry at all.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Tooling
 
+- v3 planning: opened the
+  [v3.0](https://github.com/ramongr/op-array/issues/86),
+  [v3.1](https://github.com/ramongr/op-array/issues/87),
+  [v3.2](https://github.com/ramongr/op-array/issues/88), and
+  [v3.3](https://github.com/ramongr/op-array/issues/89) milestones with
+  roadmap issues and amended `AGENTS.md` to describe the v3 target
+  state: data-first + options-object calling convention (with a
+  carve-out for set/predicate/pair-helper functions whose multiple args
+  are pure data), dot-paths everywhere, per-function `Options` types,
+  and a richer empty-input table covering the v3 contract changes
+  (`existsAll` vacuous truth, `min`/`max` throwing on empty, the
+  `compact` split). v2.x is now in patch-only mode for the duration of
+  v3 work.
 - Documentation site: published the existing `docs/*.md` and
   `CHANGELOG.md` to <https://ramongr.github.io/op-array> via an Astro
   Starlight project under `site/`. The root markdown remains the source


### PR DESCRIPTION
## Summary

Lays down the v3 conventions in `AGENTS.md` ahead of any code changes,
so every subsequent v3 PR has a single reference to conform to.

## Changes

- **v3-in-progress banner** at the top of `AGENTS.md` linking to the
  v3.0–v3.3 roadmap issues (#86, #87, #88, #89). v2.x declared in
  patch-only mode.
- **New `Calling convention` section** — data-first + options-object
  across every multi-arg function, with a carve-out documented for
  pure-data multi-array functions (`intersection`, `union`, `except`,
  `symmetricDifference`, `setEquals`, `isSubset`, `isSuperset`,
  `isDisjoint`, `exists`, `existsAll`, `existsAny`, `zip`).
- **Per-function `Options` type convention** with an example
  (`FindByOptions<T, P>`).
- **Dot-path key access rule promoted**: now governs every key/path
  field in the public API (single-key, multi-key arrays via `Paths<T>`,
  results inferred via `Get<T, P>`).
- **Empty-input table expanded** to cover the v3 contract changes:
  - `min`, `max`, `range`, `variance`, `standardDeviation`, `quantile`
    moved into the throwing fold row (A2).
  - `existsAll`/`isSubset`/`isSuperset`/`isDisjoint`/`setEquals` split
    into a new `Set-theoretic predicate` row with vacuous-truth
    semantics (A1).
  - `occurrences` documented as returning a `Map` (B5).
  - `compactNullish` and `compactFalsy` listed (A3).
  - `find item by criterion` row enumerated to include `findBy`,
    `where`, `first`, `last`, `nth`.
- **Documentation section**: CHANGELOG entries land under
  `[Unreleased]`; v3.0 PRs additionally include a **Migration** section
  in the PR body for later aggregation into `MIGRATION-v3.md`.
- **`CHANGELOG.md`** Tooling entry under `[Unreleased]` describing the
  v3 planning + AGENTS.md amendment.

No code, no tests, no build changes. Quality gate (lint + typecheck +
test + build) passes locally and is unchanged.

## Migration

Not applicable for this PR (process change only). Per-function
migration content begins with the next v3 PR.

Refs #86